### PR TITLE
fixes a zero-length format string warning (gcc-4.9 confirmed)

### DIFF
--- a/testers/atf_helpers.c
+++ b/testers/atf_helpers.c
@@ -166,7 +166,7 @@ ATF_TC_HEAD(print_config, tc)
 {
     if (atf_tc_has_config_var(tc, "config_in_list_cookie")) {
         const char* name = atf_tc_get_config_var(tc, "config_in_list_cookie");
-        atf_utils_create_file(name, "");
+        atf_utils_create_file(name, "%s", "");
     }
 }
 ATF_TC_BODY(print_config, tc)


### PR DESCRIPTION
The warning causes the build of kyua to fail due to -Werror being set:

```
$ make
(...)
testers/atf_helpers.c: In function ‘atfu_print_config_head’:
testers/atf_helpers.c:169:9: error: zero-length gnu_printf format string [-Werror=format-zero-length]
         atf_utils_create_file(name, "");
         ^
cc1: all warnings being treated as errors
Makefile:6029: recipe for target 'testers/testers_atf_helpers-atf_helpers.o' failed
make[1]: *** [testers/testers_atf_helpers-atf_helpers.o] Error 1
make[1]: Leaving directory '/home/namor/clones/kyua_namore'
Makefile:3448: recipe for target 'all' failed
make: *** [all] Error 2
$ gcc --version
gcc (Debian 4.9.1-16) 4.9.1
(...)
```
