### PR TITLE
Do not write out invalid characters to XML file.

### DIFF
--- a/utils/text/operations_test.cpp
+++ b/utils/text/operations_test.cpp
@@ -77,6 +77,7 @@ ATF_TEST_CASE_BODY(escape_xml__no_escaping)
 {
     ATF_REQUIRE_EQ("a", text::escape_xml("a"));
     ATF_REQUIRE_EQ("Some text!", text::escape_xml("Some text!"));
+    ATF_REQUIRE_EQ("\n\t\r", text::escape_xml("\n\t\r"));
 }
 
 
@@ -90,6 +91,8 @@ ATF_TEST_CASE_BODY(escape_xml__some_escaping)
 
     ATF_REQUIRE_EQ("&quot;&amp;&lt;&gt;&apos;", text::escape_xml("\"&<>'"));
     ATF_REQUIRE_EQ("&amp;&amp;&amp;", text::escape_xml("&&&"));
+    ATF_REQUIRE_EQ("&amp;#8;&amp;#11;", text::escape_xml("\b\v"));
+    ATF_REQUIRE_EQ("\t&amp;#127;BAR&amp;", text::escape_xml("\t\x7f""BAR&"));
 }
 
 


### PR DESCRIPTION
```
For special characters such as: <, >, or ', write them out
to the file as:
    &#[decimal ASCII value];

Character     Written to    Appears in Jenkins
to encode     XML file      test result viewer
=========     ==========    ==================
  <            &lt;             <
  >            &gt;             >
  '            &apos;           '
  &            &amp;            &
  "            &quot;           "

For characters which are listed as RestrictedChar
in http://www.w3.org/TR/xml11/#charsets , these characters
are completely invalid XML, and cannot even be escaped.

Character     Written to    Appears in Jenkins
to encode     XML file      test result viewer
=========     ==========    ==================
  0x08         &amp;#8;          &#8;
  0x1F         &amp;#31;         &#31;

This will at least generate a valid XML file,
but let us see where these restricted characters would
appear in the output.
```

Fixes #136
