### PR TITLE
utils: address the deprecated readdir_r function usage

### DIFF
--- a/utils/fs/directory.cpp
+++ b/utils/fs/directory.cpp
@@ -128,23 +128,7 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
     /// not.  A null pointer means an invalid iterator.
     ::DIR* _dirp;
 
-    /// Raw representation of the system directory entry.
-    ///
-    /// We need to keep this at the class level so that we can use the
-    /// readdir_r(3) function.
-    ///
-    /// Workaround for some systems (namely, illumos) requiring the readdir_r()
-    /// consumers to provide space for d_name.
-    union {
-        ::dirent _dirent;
-        char __dirent[sizeof(::dirent) + NAME_MAX];
-    };
-
     /// Custom representation of the directory entry.
-    ///
-    /// This is separate from _dirent because this is the type we return to the
-    /// user.  We must keep this as a pointer so that we can support the common
-    /// operators (* and ->) over iterators.
     std::auto_ptr< directory_entry > _entry;
 
     /// Constructs an iterator pointing to the "end" of the directory.
@@ -199,22 +183,20 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
     /// It is possible to use this function on a new directory_entry object to
     /// initialize the first entry.
     ///
-    /// \throw system_error If the call to readdir_r fails.
+    /// \throw system_error If the call to readdir fails.
     void
     next(void)
     {
         ::dirent* result;
 
-        if (::readdir_r(_dirp, &_dirent, &result) == -1) {
-            const int original_errno = errno;
-            throw fs::system_error(F("readdir_r(%s) failed") % _path,
-                                   original_errno);
-        }
+        // TODO(ngie): use `std::filesystem::directory_iterator` once the
+        // minimum C++ standard is C++20.
+        result = ::readdir(_dirp);
         if (result == NULL) {
             _entry.reset(NULL);
             close();
         } else {
-            _entry.reset(new directory_entry(_dirent.d_name));
+            _entry.reset(new directory_entry(result->d_name));
         }
     }
 };


### PR DESCRIPTION
Replace `readdir_r` usage with `readdir` as multiple sources claim that
`readdir` must be threadsafe. In Linux (at least), this function has 
been marked deprecated because of this reasoning. FreeBSD and NetBSD 
have both had threadsafe implementations of `readdir` over the past
decade.
    
This fixes `-Wdeprecated-declarations` issues with gcc, etc.
    
Co-authored-by: Enji Cooper <ngie@FreeBSD.org>