### PR TITLE
Fix compilation with clang 7.0.1

### DIFF
--- a/cli/cmd_help_test.cpp
+++ b/cli/cmd_help_test.cpp
@@ -158,7 +158,7 @@ global_test(const cmdline::options_vector& general_options,
             cmdline::ui_mock& ui)
 {
     cmdline::commands_map< cli::cli_command > mock_commands;
-    setup(mock_commands);
+    ::setup(mock_commands);
 
     cmdline::args_vector args;
     args.push_back("help");
@@ -236,7 +236,7 @@ ATF_TEST_CASE_BODY(subcommand__simple)
     cmdline::options_vector general_options;
 
     cmdline::commands_map< cli::cli_command > mock_commands;
-    setup(mock_commands);
+    ::setup(mock_commands);
 
     cmdline::args_vector args;
     args.push_back("help");
@@ -268,7 +268,7 @@ ATF_TEST_CASE_BODY(subcommand__complex)
     general_options.push_back(&global_c);
 
     cmdline::commands_map< cli::cli_command > mock_commands;
-    setup(mock_commands);
+    ::setup(mock_commands);
 
     cmdline::args_vector args;
     args.push_back("help");
@@ -309,7 +309,7 @@ ATF_TEST_CASE_BODY(subcommand__unknown)
     cmdline::options_vector general_options;
 
     cmdline::commands_map< cli::cli_command > mock_commands;
-    setup(mock_commands);
+    ::setup(mock_commands);
 
     cmdline::args_vector args;
     args.push_back("help");
@@ -330,7 +330,7 @@ ATF_TEST_CASE_BODY(invalid_args)
     cmdline::options_vector general_options;
 
     cmdline::commands_map< cli::cli_command > mock_commands;
-    setup(mock_commands);
+    ::setup(mock_commands);
 
     cmdline::args_vector args;
     args.push_back("help");


### PR DESCRIPTION
clang 7.0.1 is noting that there's an issue with compiling the tests
because they're overloading another method in the same scope with a
different, incompatible signature

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>