### PR TITLE
Ignore all backup files (that end with `~`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *_helpers
 *_inttest
 *_test
+*~
 
 .deps
 .dirstamp


### PR DESCRIPTION
This backup file is created when `autoreconf -i -s` is run if a
`config.h.in` file already exists. It should never be committed to the
repo.
    
Extend this to the more general case by ignoring all files suffixed with `~`.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>