### PR TITLE
Require Ubuntu Xenial instead of Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty  # Needed for C++11 support.
 language: cpp
 sudo: required
 
@@ -18,6 +17,10 @@ env:
     - ARCH=i386 DO=distcheck AS_ROOT=no
 
 matrix:
+    include:
+        - os: linux
+          dist: xenial
+          env: OS=ubuntu:xenial
     exclude:
         # Treat clang as the main compiler.  For gcc, just run the AS_ROOT=no
         # env above to see if we can actually build, but do not really worry

--- a/admin/travis-install-deps.sh
+++ b/admin/travis-install-deps.sh
@@ -29,7 +29,7 @@
 
 set -e -x
 
-install_deps() {
+install_deps_ubuntu_linux() {
     local pkgsuffix=
     local packages=
     if [ "${ARCH?}" = i386 ]; then
@@ -73,7 +73,17 @@ main() {
         echo "DO must be defined" 1>&2
         exit 1
     fi
-    install_deps
+
+    case "${OS}" in
+    *ubuntu*)
+        install_deps_ubuntu_linux
+	;;
+    *)
+        echo "Unsupported operating system: $(uname -o)" 1>&2
+        exit 1
+	;;
+    esac
+
     install_kyua
     for step in ${DO}; do
         "do_${DO}" || exit 1


### PR DESCRIPTION
Ubuntu Trusty Tahr is EOL at the end of next month and support has
been deprecated within the Travis project. Use Xenial instead of
Trusty, as it is supported by Ubuntu and Travis.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>