### PR TITLE
Ignore `ax_cxx_compile_stdcxx.m4` when running `make check-style`

### DIFF
--- a/admin/check-style.sh
+++ b/admin/check-style.sh
@@ -83,6 +83,7 @@ guess_rules() {
     local file="${1}"; shift
 
     case "${file}" in
+        */ax_cxx_compile_stdcxx.m4) ;;
         */ltmain.sh) ;;
         *Makefile*) echo common make ;;
         *.[0-9]) echo common man ;;


### PR DESCRIPTION
`ax_cxx_compile_stdcxx.m4` currently fails `make check-style` due to
line lengths. Ignore the style issues though, given that it's a contributed
m4 file.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>