### PR TITLE
Upgrade Ubuntu image from Trusty to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,45 @@
-dist: trusty  # Needed for C++11 support.
 language: cpp
 sudo: required
-
-compiler:
-    - clang
-    - gcc
 
 before_install:
     - ./admin/travis-install-deps.sh
 
-env:
-    - ARCH=amd64 DO=apidocs
-    - ARCH=amd64 DO=style
-    - ARCH=amd64 DO=distcheck AS_ROOT=no
-    - ARCH=amd64 DO=distcheck AS_ROOT=yes UNPRIVILEGED_USER=no
-    - ARCH=amd64 DO=distcheck AS_ROOT=yes UNPRIVILEGED_USER=yes
-    - ARCH=i386 DO=distcheck AS_ROOT=no
-
 matrix:
-    exclude:
-        # Treat clang as the main compiler.  For gcc, just run the AS_ROOT=no
-        # env above to see if we can actually build, but do not really worry
-        # about the run-time aspects of the tests.
-        - compiler: gcc
+    include:
+        - os: linux
+          dist: xenial
+          compiler: clang
+          env: ARCH=amd64 DO=distcheck AS_ROOT=no
+        - os: linux
+          dist: xenial
+          compiler: gcc
+          env: ARCH=amd64 DO=distcheck AS_ROOT=no
+        - os: linux
+          dist: xenial
+          compiler: clang
           env: ARCH=amd64 DO=apidocs
-        - compiler: gcc
+        - os: linux
+          dist: xenial
+          compiler: clang
           env: ARCH=amd64 DO=style
-        - compiler: gcc
+        - os: linux
+          dist: xenial
+          compiler: clang
           env: ARCH=amd64 DO=distcheck AS_ROOT=yes UNPRIVILEGED_USER=no
-        - compiler: gcc
+        - os: linux
+          dist: xenial
+          compiler: clang
           env: ARCH=amd64 DO=distcheck AS_ROOT=yes UNPRIVILEGED_USER=yes
+        # TODO(ngie): reenable i386; the libraries were not available in the
+        #             Ubuntu Xenial x86_64 docker image.
+        #- os: linux
+        #  dist: xenial
+        #  compiler: clang
+        #  env: ARCH=i386 DO=distcheck AS_ROOT=no
+        #- os: linux
+        #  dist: xenial
+        #  compiler: gcc
+        #  env: ARCH=i386 DO=distcheck AS_ROOT=no
 
 script:
     - ./admin/travis-build.sh

--- a/admin/travis-install-deps.sh
+++ b/admin/travis-install-deps.sh
@@ -50,8 +50,8 @@ install_deps() {
 }
 
 install_kyua() {
-    local name="20170225-usr-local-kyua-ubuntu-14-04-${ARCH?}-${CC?}.tar.gz"
-    wget "http://dl.bintray.com/jmmv/kyua/${name}" || return 1
+    local name="20190321-usr-local-kyua-ubuntu-16-04-${ARCH?}-${CC?}.tar.gz"
+    wget -O "${name}" "http://dl.bintray.com/ngie-eign/kyua/${name}" || return 1
     sudo tar -xzvp -C / -f "${name}"
     rm -f "${name}"
 }


### PR DESCRIPTION
This change requires #194 and #197 in order for all Travis CI targets to complete cleanly, but it can be merged separately in order to make forward progress, as Travis is currently completely broken.