### PR TITLE
Use namespace shorthand for `utils::config`: `config`

### DIFF
--- a/engine/scheduler.cpp
+++ b/engine/scheduler.cpp
@@ -513,7 +513,7 @@ void
 scheduler::interface::exec_cleanup(
     const model::test_program& /* test_program */,
     const std::string& /* test_case_name */,
-    const utils::config::properties_map& /* vars */,
+    const config::properties_map& /* vars */,
     const utils::fs::path& /* control_directory */) const
 {
     // Most test interfaces do not support standalone cleanup routines so

--- a/engine/tap.cpp
+++ b/engine/tap.cpp
@@ -140,12 +140,12 @@ void
 engine::tap_interface::exec_test(
     const model::test_program& test_program,
     const std::string& test_case_name,
-    const utils::config::properties_map& vars,
+    const config::properties_map& vars,
     const fs::path& /* control_directory */) const
 {
     PRE(test_case_name == "main");
 
-    for (utils::config::properties_map::const_iterator iter = vars.begin();
+    for (config::properties_map::const_iterator iter = vars.begin();
          iter != vars.end(); ++iter) {
         utils::setenv(F("TEST_ENV_%s") % (*iter).first, (*iter).second);
     }


### PR DESCRIPTION
Reported-by: Justine Akehurst <justine.akehurst@protonmail.ch>
Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>