### PR TITLE
CI: Add Cirrus-CI config for FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+freebsd_instance:
+  image: freebsd-12-1-release-amd64
+
+task:
+  install_script: pkg install -y
+    autoconf automake libtool m4 pkgconf
+    atf
+    lua52 lutok sqlite3
+
+  script: |
+    autoreconf -i -s
+    ./configure
+    make distcheck


### PR DESCRIPTION
Right now this executes only `make distcheck` and does not rely on any
of the scripts under admin/ used by the travis CI config.