### PR TITLE
Fix broken links and format markdown

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,4 @@
-Installation instructions
-=========================
+# Installation instructions
 
 Kyua uses the GNU Automake, GNU Autoconf and GNU Libtool utilities as
 its build system.  These are used only when compiling the application
@@ -25,8 +24,7 @@ Or alternatively, install as a regular user into your home directory:
     $ make installcheck
 
 
-Dependencies
-------------
+## Dependencies
 
 To build and use Kyua successfully you need:
 
@@ -48,8 +46,7 @@ need the following tools:
 * GNU Libtool.
 
 
-Regenerating the build system
------------------------------
+## Regenerating the build system
 
 This is not necessary if you are building from a formal release
 distribution file.
@@ -72,8 +69,7 @@ the appropriate path:
     $ autoreconf -i -s -I <atf-prefix>/share/aclocal
 
 
-General build procedure
------------------------
+## General build procedure
 
 To build and install the source package, you must follow these steps:
 
@@ -102,8 +98,7 @@ To build and install the source package, you must follow these steps:
    not, some checks will be skipped.
 
 
-Configuration flags
--------------------
+## Configuration flags
 
 The most common, standard flags given to `configure` are:
 
@@ -227,8 +222,7 @@ The following flags are specific to Kyua's `configure` script:
   binary, which must exist.
 
 
-Post-installation steps
------------------------
+## Post-installation steps
 
 Copy the `Kyuafile.top` file installed in the examples directory to the
 root of your tests hierarchy and name it `Kyuafile`.  For example:
@@ -240,8 +234,7 @@ This will allow you to simply go into `/usr/tests` and run the tests
 from there.
 
 
-Run the tests!
---------------
+## Run the tests!
 
 Lastly, after a successful installation, you should periodically run the
 tests from the final location to ensure things remain stable.  Do so as

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -261,8 +261,7 @@ suite and can be given to Kyua with arguments of the form
   dump core.  Such tests are particularly slow on macOS, and it is
   sometimes handy to disable them for quicker development iteration.
 
-If you see any tests fail, do not hesitate to report them in:
-
-    https://github.com/jmmv/kyua/issues/
+If you see any tests fail, do not hesitate to report them on
+[GitHub issues](https://github.com/freebsd/kyua/issues/).
 
 Thank you!

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,17 +1,13 @@
-Major changes between releases
-==============================
+# Major changes between releases
 
-
-Changes in version 0.14
------------------------
+## Changes in version 0.14
 
 **NOT RELEASED YET; STILL UNDER DEVELOPMENT.**
 
 * Explicitly require C++11 language features when compiling Kyua.
 
 
-Changes in version 0.13
------------------------
+## Changes in version 0.13
 
 **Released on August 26th, 2016.**
 
@@ -36,8 +32,7 @@ Changes in version 0.13
   timers to control test deadlines.
 
 
-Changes in version 0.12
------------------------
+## Changes in version 0.12
 
 **Released on November 22nd, 2015.**
 
@@ -129,8 +124,7 @@ parallelization possibilities.
   Markdown for better formatting online.
 
 
-Changes in version 0.11
------------------------
+## Changes in version 0.11
 
 **Released on October 23rd, 2014.**
 
@@ -211,8 +205,7 @@ Changes in version 0.11
   examples.
 
 
-Changes in version 0.10
------------------------
+## Changes in version 0.10
 
 **Experimental version released on August 14th, 2014.**
 
@@ -232,8 +225,7 @@ Changes in version 0.10
   prevent triggering a core dump that made the test fail in some platforms.
 
 
-Changes in kyua-cli version 0.9
--------------------------------
+## Changes in kyua-cli version 0.9
 
 **Experimental version released on August 8th, 2014.**
 
@@ -276,8 +268,7 @@ Changes in more detail:
   files.
 
 
-Changes in kyua-testers version 0.3
------------------------------------
+## Changes in kyua-testers version 0.3
 
 **Experimental version released on August 8th, 2014.**
 
@@ -293,8 +284,7 @@ Changes in kyua-testers version 0.3
   handle test programs that report a pass but exit with a non-zero code.
 
 
-Changes in kyua-cli version 0.8
--------------------------------
+## Changes in kyua-cli version 0.8
 
 **Experimental version released on December 7th, 2013.**
 
@@ -310,8 +300,7 @@ Changes in kyua-cli version 0.8
   the addition of new testers or the selective installation of them.
 
 
-Changes in kyua-testers version 0.2
------------------------------------
+## Changes in kyua-testers version 0.2
 
 **Experimental version released on December 7th, 2013.**
 
@@ -326,8 +315,7 @@ Changes in kyua-testers version 0.2
   own session instead of just to their own process group.
 
 
-Changes in kyua-cli version 0.7
--------------------------------
+## Changes in kyua-cli version 0.7
 
 **Experimental version released on October 18th, 2013.**
 
@@ -347,8 +335,7 @@ Changes in kyua-cli version 0.7
   LTS, which appears stuck in 1.11.1.
 
 
-Changes in kyua-cli version 0.6
--------------------------------
+## Changes in kyua-cli version 0.6
 
 **Experimental version released on February 22nd, 2013.**
 
@@ -412,8 +399,7 @@ Changes in kyua-cli version 0.6
   executables.
 
 
-Changes in kyua-testers version 0.1
------------------------------------
+## Changes in kyua-testers version 0.1
 
 **Experimental version released on February 19th, 2013.**
 
@@ -430,8 +416,7 @@ of `kyua-cli`, which means that the overall build times of Kyua are now
 reduced.
 
 
-Changes in kyua-cli version 0.5
--------------------------------
+## Changes in kyua-cli version 0.5
 
 **Experimental version released on July 10th, 2012.**
 
@@ -454,8 +439,7 @@ Changes in kyua-cli version 0.5
   from the repository.
 
 
-Changes in kyua-cli version 0.4
--------------------------------
+## Changes in kyua-cli version 0.4
 
 **Experimental version released on June 6th, 2012.**
 
@@ -497,8 +481,7 @@ Changes in kyua-cli version 0.4
   such tree.
 
 
-Changes in kyua-cli version 0.3
--------------------------------
+## Changes in kyua-cli version 0.3
 
 **Experimental version released on February 24th, 2012.**
 
@@ -533,8 +516,7 @@ Changes in kyua-cli version 0.3
   failing test.
 
 
-Changes in kyua-cli version 0.2
--------------------------------
+## Changes in kyua-cli version 0.2
 
 **Experimental version released on August 24th, 2011.**
 
@@ -599,8 +581,7 @@ Without further ado, here comes the itemized list of changes:
   and Ubuntu 10.04.1 LTS.  (Issues #20, #21, #26.)
 
 
-Changes in kyua-cli version 0.1
--------------------------------
+## Changes in kyua-cli version 0.1
 
 **Experimental version released on June 23rd, 2011.**
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on a production machine.
 
 Kyua is **able to execute test programs written with a plethora of testing
 libraries and languages**.  The library of choice is
-[ATF](https://github.com/jmmv/atf/), for which Kyua was originally
+[ATF](https://github.com/freebsd/atf/), for which Kyua was originally
 designed, but simple, framework-less test programs and TAP-compliant test
 programs can also be executed through Kyua.
 
@@ -60,7 +60,7 @@ here, follow the instructions in the
 
 You should also install the ATF libraries to assist in the development of
 test programs.  To that end, see the
-[ATF project page](https://github.com/jmmv/atf/).
+[ATF project page](https://github.com/freebsd/atf/).
 
 
 Contributing
@@ -81,4 +81,4 @@ Please use the [kyua-discuss mailing
 list](https://groups.google.com/forum/#!forum/kyua-discuss) for any support
 inquiries.
 
-*Homepage:* https://github.com/jmmv/kyua/
+*Homepage:* https://github.com/freebsd/kyua/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Welcome to the Kyua project!
-============================
+# Welcome to the Kyua project!
 
 Kyua is a **testing framework** for infrastructure software, originally
 designed to equip BSD-based operating systems with a test suite.  This
@@ -26,8 +25,7 @@ This is not an official Google product.
 [Read more about Kyua in the About wiki page.](../../wiki/About)
 
 
-Download
---------
+## Download
 
 The latest version of Kyua is 0.13 and was released on August 26th, 2016.
 
@@ -37,8 +35,7 @@ See the [release notes](NEWS.md) for information about the changes in this
 and all previous releases.
 
 
-Installation
-------------
+## Installation
 
 You are encouraged to install binary packages for your operating system
 wherever available:
@@ -63,8 +60,7 @@ test programs.  To that end, see the
 [ATF project page](https://github.com/freebsd/atf/).
 
 
-Contributing
-------------
+## Contributing
 
 Want to contribute?  Great!  But please first read the guidelines provided
 in [CONTRIBUTING.md](CONTRIBUTING.md).
@@ -74,8 +70,7 @@ the [list of copyright holders](AUTHORS) and the [list of
 individuals](CONTRIBUTORS).
 
 
-Support
--------
+## Support
 
 Please use the [kyua-discuss mailing
 list](https://groups.google.com/forum/#!forum/kyua-discuss) for any support

--- a/configure.ac
+++ b/configure.ac
@@ -63,16 +63,16 @@ AC_PROG_RANLIB
 
 
 m4_ifndef([PKG_CHECK_MODULES],
-    [m4_fatal([Cannot find pkg.m4; see the INSTALL document for help])])
+    [m4_fatal([Cannot find pkg.m4; see the INSTALL.md document for help])])
 
 m4_ifndef([ATF_CHECK_CXX],
-    [m4_fatal([Cannot find atf-c++.m4; see the INSTALL document for help])])
+    [m4_fatal([Cannot find atf-c++.m4; see the INSTALL.md document for help])])
 ATF_CHECK_CXX([>= 0.17])
 m4_ifndef([ATF_CHECK_SH],
-    [m4_fatal([Cannot find atf-sh.m4; see the INSTALL document for help])])
+    [m4_fatal([Cannot find atf-sh.m4; see the INSTALL.md document for help])])
 ATF_CHECK_SH([>= 0.15])
 m4_ifndef([ATF_ARG_WITH],
-    [m4_fatal([Cannot find atf-common.m4; see the INSTALL document for help])])
+    [m4_fatal([Cannot find atf-common.m4; see the INSTALL.md document for help])])
 ATF_ARG_WITH
 
 PKG_CHECK_MODULES([LUTOK], [lutok >= 0.4],


### PR DESCRIPTION
- Make the header formatting explicit with markdown using `#` instead of alternate long form headers.
- Update documentation to refer in autotools output to reference the markdown docs.
- Update links to point to the freebsd org instead of jmmv's user account, since this @jmmv transferred ownership of his projects to the @freebsd org.