### PR TITLE
Reference the freebsd org instead of jmmv's user account

### DIFF
--- a/admin/build-bintray-dist.sh
+++ b/admin/build-bintray-dist.sh
@@ -74,7 +74,7 @@ install_from_github() {
 
     local distname="${name}-${release}"
 
-    local baseurl="https://github.com/jmmv/${name}"
+    local baseurl="https://github.com/freebsd/${name}"
     wget --no-check-certificate \
         "${baseurl}/releases/download/${distname}/${distname}.tar.gz"
     tar -xzvf "${distname}.tar.gz"

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ dnl (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 AC_INIT([Kyua], [0.14], [kyua-discuss@googlegroups.com], [kyua],
-        [https://github.com/jmmv/kyua/])
+        [https://github.com/freebsd/kyua/])
 AC_PREREQ([2.65])
 
 

--- a/doc/kyua.1.in
+++ b/doc/kyua.1.in
@@ -280,13 +280,13 @@ The first step in reporting a bug is to check if there already is a similar
 bug in the database.
 You can check what issues are currently in the database by going to:
 .Bd -literal -offset indent
-https://github.com/jmmv/kyua/issues/
+https://github.com/freebsd/kyua/issues/
 .Ed
 .Pp
 If there is no existing issue that describes an issue similar to the
 one you are experiencing, you can open a new one by visiting:
 .Bd -literal -offset indent
-https://github.com/jmmv/kyua/issues/new/
+https://github.com/freebsd/kyua/issues/new/
 .Ed
 .Pp
 When doing so, please include as much detail as possible.


### PR DESCRIPTION
This finishes documenting the transition for multiple kyua-related
projects from @jmmv's personal GitHub account to the https://github.com/freebsd github
org.