### PR TITLE
Fix running `executor_pid_test` on ZFS

### DIFF
--- a/utils/process/Kyuafile
+++ b/utils/process/Kyuafile
@@ -6,7 +6,7 @@ atf_test_program{name="child_test"}
 atf_test_program{name="deadline_killer_test"}
 atf_test_program{name="exceptions_test"}
 atf_test_program{name="executor_test"}
-atf_test_program{name="executor_pid_test"}
+atf_test_program{name="executor_pid_test", required_user="root"}
 atf_test_program{name="fdstream_test"}
 atf_test_program{name="isolation_test"}
 atf_test_program{name="operations_test"}

--- a/utils/process/Makefile.am.inc
+++ b/utils/process/Makefile.am.inc
@@ -84,8 +84,8 @@ utils_process_executor_test_CXXFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
 utils_process_executor_test_LDADD = $(UTILS_LIBS) $(ATF_CXX_LIBS)
 
 tests_utils_process_PROGRAMS += utils/process/executor_pid_test
-utils_process_executor_pid_test_SOURCES = utils/process/executor_pid_test.cpp
-utils_process_executor_pid_test_CXXFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
+utils_process_executor_pid_test_SOURCES = utils/process/executor_pid_test.c
+utils_process_executor_pid_test_CFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
 utils_process_executor_pid_test_LDADD = $(UTILS_LIBS) $(ATF_CXX_LIBS)
 
 tests_utils_process_PROGRAMS += utils/process/fdstream_test


### PR DESCRIPTION
The testcases prior to this change relied on setting UF_NOUNLINK, which is unfortunately bugged on ZFS: ZFS does not treat UF_NOUNLINK as a valid value for fflags, which causes the testcases to fail.

Switch to SF_NOUNLINK. This particular fflag works work ZFS, unlike UF_NOUNLINK, but requires root privileges, so add the needed metadata to the Kyuafile.

As part of this, I needed to convert the test from atf-c++(3) to atf-c(3). The atf-c++(3) APIs do not have the printf-like equivalent formatting, so it was very difficult figuring out why things weren't working in atf-c++(3).

While here, clean up the code to DRY some of the repeated logic that it contained.

The UF_NOUNLINK bug has been reported in https://github.com/openzfs/zfs/issues/16809 .

Fixes:  e26c8047f7299f046f87308705b062973d686f5f