### PR TITLE
Add closing brace to unbreak the build on FreeBSD/MacOS

### DIFF
--- a/store/write_transaction_test.cpp
+++ b/store/write_transaction_test.cpp
@@ -148,7 +148,7 @@ ATF_TEST_CASE_BODY(commit__fail)
         backend.database().exec(bad_sql);
         ATF_REQUIRE_THROW(store::error, tx.commit());
 #else
-        ATF_REQUIRE_THROW(sqlite::api_error, backend.database().exec(bad_sql);
+        ATF_REQUIRE_THROW(sqlite::api_error, backend.database().exec(bad_sql));
 #endif
     }
     // If the code attempts to maintain any state regarding the already-put


### PR DESCRIPTION
Fixes:	f7ac5e0f3fa806cb417277f63e738a9e862c64b0