### PR TITLE
store/write_transaction_test: revert recent changes

### DIFF
--- a/store/write_transaction_test.cpp
+++ b/store/write_transaction_test.cpp
@@ -137,19 +137,8 @@ ATF_TEST_CASE_BODY(commit__fail)
         backend.database().exec(
             "CREATE TABLE foo ("
             "a REFERENCES env_vars(var_name) DEFERRABLE INITIALLY DEFERRED)");
-        // For whatever reason, multiple Linux distros seem to execute the
-        // sqlite statements differently from BSD-based OSes. The exception is
-        // raised on transaction commit in Linux, whereas it's executed
-        // immediately with BSD-based OSes. Linux's behavior seems more
-        // correct, because a deferred transaction was started, but not
-        // committed.
-        const char *bad_sql = "INSERT INTO foo VALUES ('WHAT')";
-#if defined(__linux__)
-        backend.database().exec(bad_sql);
+        backend.database().exec("INSERT INTO foo VALUES ('WHAT')");
         ATF_REQUIRE_THROW(store::error, tx.commit());
-#else
-        ATF_REQUIRE_THROW(sqlite::api_error, backend.database().exec(bad_sql));
-#endif
     }
     // If the code attempts to maintain any state regarding the already-put
     // objects and the commit does not clean up correctly, this would fail in


### PR DESCRIPTION
f7ac5e0f3fa806cb417277f63e738a9e862c64b0 (and 16f55309bdd233e529586a77b659eb0c3300b6ec) introduced a test workaround on FreeBSD for an issue that doesn't reproduce on 14.1-RELEASE-p4.

Revert the workaround, getting back to prior behavior with this test on FreeBSD.

Closes:	#240