### PR TITLE
Support is_exclusive metadata coming from an ATF test case

### DIFF
--- a/engine/atf_list.cpp
+++ b/engine/atf_list.cpp
@@ -125,6 +125,8 @@ engine::parse_atf_metadata(const model::properties_map& props)
                 mdbuilder.set_string("execenv", value);
             } else if (name == "execenv.jail.params") {
                 mdbuilder.set_string("execenv_jail_params", value);
+            } else if (name == "is.exclusive") {
+                mdbuilder.set_string("is_exclusive", value);
             } else if (name == "require.config") {
                 mdbuilder.set_string("required_configs", value);
             } else if (name == "require.files") {


### PR DESCRIPTION
On ATF side it is named "is.exclusive".