### PR TITLE
Fix out-of-tree builds

### DIFF
--- a/utils/process/Makefile.am.inc
+++ b/utils/process/Makefile.am.inc
@@ -63,8 +63,8 @@ tests_utils_process_DATA = utils/process/Kyuafile
 EXTRA_DIST += $(tests_utils_process_DATA)
 
 CLEANFILES+=	utils/process/Kyuafile
-utils/process/Kyuafile: utils/process/Kyuafile.in
-	cp -f utils/process/Kyuafile.in utils/process/Kyuafile.tmp
+utils/process/Kyuafile: $(top_srcdir)/utils/process/Kyuafile.in
+	cp -f $(top_srcdir)/utils/process/Kyuafile.in utils/process/Kyuafile.tmp
 if FreeBSD
 	printf 'atf_test_program{name="executor_pid_test", required_user="root"}\n' >> \
 	    utils/process/Kyuafile.tmp


### PR DESCRIPTION
Kyuafile.in comes from the source directory. It needs to be referenced with `top_srcdir` in order to work with out-of-tree builds.

Fixes:	89bf71c66507f654114ea62d0b7f16b6c4c39e13