### PR TITLE
Require newer versions of ATF and Lutok

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,17 +64,17 @@ m4_ifndef([PKG_CHECK_MODULES],
 
 m4_ifndef([ATF_CHECK_CXX],
     [m4_fatal([Cannot find atf-c++.m4; see the INSTALL.md document for help])])
-ATF_CHECK_CXX([>= 0.17])
+ATF_CHECK_CXX([>= 0.22])
 m4_ifndef([ATF_CHECK_SH],
     [m4_fatal([Cannot find atf-sh.m4; see the INSTALL.md document for help])])
-ATF_CHECK_SH([>= 0.15])
+ATF_CHECK_SH([>= 0.22])
 m4_ifndef([ATF_ARG_WITH],
     [m4_fatal([Cannot find atf-common.m4; see the INSTALL.md document for help])])
 ATF_ARG_WITH
 
-PKG_CHECK_MODULES([LUTOK], [lutok >= 0.4],
+PKG_CHECK_MODULES([LUTOK], [lutok >= 0.5],
                   [],
-                  AC_MSG_ERROR([lutok (0.4 or newer) is required]))
+                  AC_MSG_ERROR([lutok (0.5 or newer) is required]))
 PKG_CHECK_MODULES([SQLITE3], [sqlite3 >= 3.6.22],
                   [],
                   AC_MSG_ERROR([sqlite3 (3.6.22 or newer) is required]))

--- a/m4/atf-c++.m4
+++ b/m4/atf-c++.m4
@@ -1,0 +1,44 @@
+dnl Copyright 2011 Google Inc.
+dnl All rights reserved.
+dnl
+dnl Redistribution and use in source and binary forms, with or without
+dnl modification, are permitted provided that the following conditions are
+dnl met:
+dnl
+dnl * Redistributions of source code must retain the above copyright
+dnl   notice, this list of conditions and the following disclaimer.
+dnl * Redistributions in binary form must reproduce the above copyright
+dnl   notice, this list of conditions and the following disclaimer in the
+dnl   documentation and/or other materials provided with the distribution.
+dnl * Neither the name of Google Inc. nor the names of its contributors
+dnl   may be used to endorse or promote products derived from this software
+dnl   without specific prior written permission.
+dnl
+dnl THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+dnl "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+dnl LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+dnl A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+dnl OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+dnl SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+dnl LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+dnl DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+dnl THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+dnl (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+dnl ATF_CHECK_CXX([version-spec])
+dnl
+dnl Checks if atf-c++ is present.  If version-spec is provided, ensures that
+dnl the installed version of atf-sh matches the required version.  This
+dnl argument must be something like '>= 0.14' and accepts any version
+dnl specification supported by pkg-config.
+dnl
+dnl Defines and substitutes ATF_CXX_CFLAGS and ATF_CXX_LIBS with the compiler
+dnl and linker flags need to build against atf-c++.
+AC_DEFUN([ATF_CHECK_CXX], [
+    spec="atf-c++[]m4_default_nblank([ $1], [])"
+    _ATF_CHECK_ARG_WITH(
+        [PKG_CHECK_MODULES([ATF_CXX], [${spec}],
+                           [found=yes found_atf_cxx=yes], [found=no])],
+        [required ${spec} not found])
+])

--- a/m4/atf-c.m4
+++ b/m4/atf-c.m4
@@ -1,0 +1,44 @@
+dnl Copyright 2011 Google Inc.
+dnl All rights reserved.
+dnl
+dnl Redistribution and use in source and binary forms, with or without
+dnl modification, are permitted provided that the following conditions are
+dnl met:
+dnl
+dnl * Redistributions of source code must retain the above copyright
+dnl   notice, this list of conditions and the following disclaimer.
+dnl * Redistributions in binary form must reproduce the above copyright
+dnl   notice, this list of conditions and the following disclaimer in the
+dnl   documentation and/or other materials provided with the distribution.
+dnl * Neither the name of Google Inc. nor the names of its contributors
+dnl   may be used to endorse or promote products derived from this software
+dnl   without specific prior written permission.
+dnl
+dnl THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+dnl "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+dnl LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+dnl A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+dnl OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+dnl SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+dnl LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+dnl DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+dnl THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+dnl (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+dnl ATF_CHECK_C([version-spec])
+dnl
+dnl Checks if atf-c is present.  If version-spec is provided, ensures that
+dnl the installed version of atf-sh matches the required version.  This
+dnl argument must be something like '>= 0.14' and accepts any version
+dnl specification supported by pkg-config.
+dnl
+dnl Defines and substitutes ATF_C_CFLAGS and ATF_C_LIBS with the compiler
+dnl and linker flags need to build against atf-c.
+AC_DEFUN([ATF_CHECK_C], [
+    spec="atf-c[]m4_default_nblank([ $1], [])"
+    _ATF_CHECK_ARG_WITH(
+        [PKG_CHECK_MODULES([ATF_C], [${spec}],
+                           [found=yes found_atf_c=yes], [found=no])],
+        [required ${spec} not found])
+])

--- a/m4/atf-common.m4
+++ b/m4/atf-common.m4
@@ -1,0 +1,88 @@
+dnl Copyright 2011 Google Inc.
+dnl All rights reserved.
+dnl
+dnl Redistribution and use in source and binary forms, with or without
+dnl modification, are permitted provided that the following conditions are
+dnl met:
+dnl
+dnl * Redistributions of source code must retain the above copyright
+dnl   notice, this list of conditions and the following disclaimer.
+dnl * Redistributions in binary form must reproduce the above copyright
+dnl   notice, this list of conditions and the following disclaimer in the
+dnl   documentation and/or other materials provided with the distribution.
+dnl * Neither the name of Google Inc. nor the names of its contributors
+dnl   may be used to endorse or promote products derived from this software
+dnl   without specific prior written permission.
+dnl
+dnl THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+dnl "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+dnl LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+dnl A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+dnl OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+dnl SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+dnl LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+dnl DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+dnl THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+dnl (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+dnl ATF_ARG_WITH
+dnl
+dnl Adds a --with-atf flag to the configure script that allows the user to
+dnl enable or disable atf support.
+dnl
+dnl The ATF_CHECK_{C,CXX,SH} macros honor the flag defined herein if
+dnl instantiated.  If not instantiated, they will request the presence of
+dnl the libraries unconditionally.
+dnl
+dnl Defines the WITH_ATF Automake conditional if ATF has been found by any
+dnl of the ATF_CHECK_{C,CXX,SH} macros.
+AC_DEFUN([ATF_ARG_WITH], [
+    m4_define([atf_arg_with_called], [yes])
+
+    m4_divert_text([DEFAULTS], [with_atf=auto])
+    AC_ARG_WITH([atf],
+                [AS_HELP_STRING([--with-atf=<yes|no|auto>],
+                                [build atf-based test programs])],
+                [with_atf=${withval}], [with_atf=auto])
+
+    m4_divert_text([DEFAULTS], [
+        found_atf_c=no
+        found_atf_cxx=no
+        found_atf_sh=no
+    ])
+    AM_CONDITIONAL([WITH_ATF], [test x"${found_atf_c}" = x"yes" -o \
+                                     x"${found_atf_cxx}" = x"yes" -o \
+                                     x"${found_atf_sh}" = x"yes"])
+])
+
+dnl _ATF_CHECK_ARG_WITH(check, error_message)
+dnl
+dnl Internal macro to execute a check conditional on the --with-atf flag
+dnl and handle the result accordingly.
+dnl
+dnl 'check' specifies the piece of code to be run to detect the feature.
+dnl This code must set the 'found' shell variable to yes or no depending
+dnl on the raw result of the check.
+AC_DEFUN([_ATF_CHECK_ARG_WITH], [
+    m4_ifdef([atf_arg_with_called], [
+        m4_fatal([ATF_ARG_WITH must be called after the ATF_CHECK_* checks])
+    ])
+
+    m4_divert_text([DEFAULTS], [with_atf=yes])
+
+    if test x"${with_atf}" = x"no"; then
+        _found=no
+    else
+        $1
+        if test x"${with_atf}" = x"auto"; then
+            _found="${found}"
+        else
+            if test x"${found}" = x"yes"; then
+                _found=yes
+            else
+                AC_MSG_ERROR([$2])
+            fi
+        fi
+    fi
+])

--- a/m4/atf-sh.m4
+++ b/m4/atf-sh.m4
@@ -1,0 +1,49 @@
+dnl Copyright 2011 Google Inc.
+dnl All rights reserved.
+dnl
+dnl Redistribution and use in source and binary forms, with or without
+dnl modification, are permitted provided that the following conditions are
+dnl met:
+dnl
+dnl * Redistributions of source code must retain the above copyright
+dnl   notice, this list of conditions and the following disclaimer.
+dnl * Redistributions in binary form must reproduce the above copyright
+dnl   notice, this list of conditions and the following disclaimer in the
+dnl   documentation and/or other materials provided with the distribution.
+dnl * Neither the name of Google Inc. nor the names of its contributors
+dnl   may be used to endorse or promote products derived from this software
+dnl   without specific prior written permission.
+dnl
+dnl THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+dnl "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+dnl LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+dnl A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+dnl OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+dnl SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+dnl LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+dnl DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+dnl THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+dnl (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+dnl ATF_CHECK_SH([version-spec])
+dnl
+dnl Checks if atf-sh is present.  If version-spec is provided, ensures that
+dnl the installed version of atf-sh matches the required version.  This
+dnl argument must be something like '>= 0.14' and accepts any version
+dnl specification supported by pkg-config.
+dnl
+dnl Defines and substitutes ATF_SH with the full path to the atf-sh interpreter.
+AC_DEFUN([ATF_CHECK_SH], [
+    spec="atf-sh[]m4_default_nblank([ $1], [])"
+    _ATF_CHECK_ARG_WITH(
+        [AC_MSG_CHECKING([for ${spec}])
+         PKG_CHECK_EXISTS([${spec}], [found=yes], [found=no])
+         if test "${found}" = yes; then
+             ATF_SH="$(${PKG_CONFIG} --variable=interpreter atf-sh)"
+             AC_SUBST([ATF_SH], [${ATF_SH}])
+             found_atf_sh=yes
+         fi
+         AC_MSG_RESULT([${ATF_SH}])],
+        [required ${spec} not found])
+])


### PR DESCRIPTION
- Vendor the ATF m4 files from freebsd/atf@atf-0.22
- Require versions of ATF/Lutok which build with C++-11 / C++-14.