### PR TITLE
admin/make-release.sh: automate release creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ config.h
 kyua
 libtool
 local-kyua
+releases
 
 # Imported from https://github.com/github/gitignore/blob/main/Autotools.gitignore
 # http://www.gnu.org/software/automake

--- a/admin/make-release.exclude
+++ b/admin/make-release.exclude
@@ -1,0 +1,11 @@
+*/.cirrus.yml
+*/.github/*
+*/.gitignore
+*/.travis.yml
+*/admin*
+*/autom4te.cache/*
+*/m4/libtool.m4
+*/m4/ltoptions.m4
+*/m4/ltsugar.m4
+*/m4/ltversion.m4
+*/m4/lt~obsolete.m4

--- a/admin/make-release.sh
+++ b/admin/make-release.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Create release artifacts from a release tag.
+#
+# Example:
+# 	./admin/make-release.sh kyua-0.13
+
+set -eux
+
+tag=$1
+
+cd "$(dirname "$(dirname "$0")")"
+
+mkdir -p releases
+release_root=$(realpath releases)
+
+release_dir="${release_root}/${tag}"
+release_artifact="${release_root}/${tag}.tar.gz"
+
+rm -Rf "${release_dir}"
+mkdir -p "${release_dir}"
+git archive "${tag}" | tar xzvf - -C "${release_dir}"
+cd "${release_dir}"
+autoreconf -is
+cd "${release_root}"
+bsdtar \
+    --exclude-from=${release_dir}/admin/make-release.exclude \
+    --uname "" --gname "" \
+    --uid 0 --gid 0 \
+    -cvpzf "${release_artifact}" "${tag}"
+sha256 "${release_artifact##*/}" > "${release_artifact}.sha256"


### PR DESCRIPTION
This does the absolute bare minimum to produce a release.

This logic best resembles the expectations for legacy releases of Kyua.

Various files are omitted as they are not required in order to build from a full `autoreconf`'ed source distribution.