### PR TITLE
Add initial GitHub Actions support for kyua

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,225 @@
+---
+# GitHub action to compile and test kyua on supported platforms.
+#
+# Steps executed:
+# * Handle prerequisites
+#     * Install binary packages
+#     * Build packages from source (if needed).
+#     * Build
+#     * Install
+#     * Run tests
+#
+# On MacOS we build with:
+# * latest clang from brew (system provided clang lacks sanitizers).
+# * ld from system
+#
+env:
+    ATF_REPO: freebsd/atf
+    ATF_REF: atf-0.22
+    # LUTOK_REPO: freebsd/lutok
+    # LUTOK_REF: master
+    LUTOK_REPO: ngie-eign/lutok
+    LUTOK_REF: build-cleanup
+
+name: build
+on:
+    pull_request:
+        branches:
+            - master
+    push:
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    build:
+        name: Build ${{ matrix.build-os }} ${{ matrix.compiler }} ${{ matrix.enable-atf }}
+        runs-on: "${{ matrix.build-os }}"
+        strategy:
+            fail-fast: false
+            matrix:
+                build-os:
+                    - ubuntu-24.04
+                    - macos-latest
+                #enable-atf: [--disable-atf, --enable-atf]
+                enable-atf: [--enable-atf]
+                include:
+                    - build-os: macos-latest
+                      compiler: clang-19
+                      pkgs:
+                          - llvm@19
+                          - autoconf
+                          - automake
+                          - libtool
+                          - pkgconf
+                          - lua@5.4
+                          - sqlite
+                      enable-atf-pkgs:
+                      # gdb is not built for ARM64 yet :(.
+                      #    - gdb
+                      llvm-bindir: /opt/homebrew/opt/llvm/bin
+                    - build-os: ubuntu-24.04
+                      compiler: clang-18
+                      pkgs:
+                          - clang-18
+                          - autoconf
+                          - automake
+                          - libtool
+                          - pkgconf
+                          - liblua5.4-dev
+                          - lua5.4
+                          - libsqlite3-dev
+                      enable-atf-pkgs:
+                          - gdb
+                      llvm-bindir: /usr/lib/llvm-18/bin
+        steps:
+            - name: Install base dependencies (macOS)
+              if: runner.os == 'macOS'
+              run: |
+                  brew update -q || true
+                  brew install -q ${{ join(matrix.pkgs, ' ') }} \
+            - name: Install ATF-related dependencies (macOS)
+              if: runner.os == 'macOS' && matrix.enable-atf == '--enable-atf' && matrix.enable-atf-pkgs
+              run: |
+                  brew install -q ${{ join(matrix.enable-atf-pkgs, ' ') }}
+            - name: Install base dependencies (Ubuntu)
+              if: runner.os == 'Linux'
+              run: |
+                  sudo apt -Uqy --no-install-suggests \
+                      --no-install-recommends install \
+                      ${{ join(matrix.pkgs, ' ') }} \
+            - name: Install ATF-related dependencies (Ubuntu)
+              if: runner.os == 'Linux' && matrix.enable-atf == '--enable-atf' && matrix.enable-atf-pkgs
+              run: |
+                  sudo apt -Uqy --no-install-suggests \
+                      --no-install-recommends install \
+                      ${{ join(matrix.enable-atf-pkgs, ' ') }}
+            - name: Checking out source (ATF)
+              uses: actions/checkout@v4
+              with:
+                  repository: "${{ env.ATF_REPO }}"
+                  ref: "${{ env.ATF_REF }}"
+                  # Same as `ATF_SRCDIR`.
+                  path: "${{ github.workspace }}/atf-src"
+            - name: Checking out source (Lutok)
+              uses: actions/checkout@v4
+              with:
+                  repository: "${{ env.LUTOK_REPO }}"
+                  ref: "${{ env.LUTOK_REF }}"
+                  # Same as `LUTOK_SRCDIR`.
+                  path: "${{ github.workspace }}/lutok-src"
+            - name: Clone Kyua source
+              if: matrix.enable-atf == '--enable-atf'
+              uses: actions/checkout@v4
+              with:
+                  # Same as `KYUA_SRCDIR`.
+                  path: "${{ github.workspace }}/kyua-src"
+            - name: Setup Environment
+              run: |
+                  echo "AR=${{ matrix.llvm-bindir }}/llvm-ar" >> "${GITHUB_ENV}"
+                  echo "CC=${{ matrix.llvm-bindir }}/clang" >> "${GITHUB_ENV}"
+                  echo "CPP=${{ matrix.llvm-bindir }}/clang-cpp" >> "${GITHUB_ENV}"
+                  echo "CXX=${{ matrix.llvm-bindir }}/clang++" >> "${GITHUB_ENV}"
+                  echo "NM=${{ matrix.llvm-bindir }}/llvm-nm" >> "${GITHUB_ENV}"
+                  echo "PKG_CONFIG_PATH='$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig'" >> "${GITHUB_ENV}"
+                  echo "RANLIB=${{ matrix.llvm-bindir }}/llvm-ranlib" >> "${GITHUB_ENV}"
+                  echo "OBJDUMP=${{ matrix.llvm-bindir }}/llvm-objdump" >> "${GITHUB_ENV}"
+                  echo "STRIP=${{ matrix.llvm-bindir }}/llvm-strip" >> "${GITHUB_ENV}"
+                  echo "ATF_SRCDIR=${GITHUB_WORKSPACE}/atf-src" >> "${GITHUB_ENV}"
+                  echo "ATF_OBJDIR=${GITHUB_WORKSPACE}/atf-obj" >> "${GITHUB_ENV}"
+                  echo "KYUA_HOME=${GITHUB_WORKSPACE}/kyua-obj/.kyua" >> "${GITHUB_ENV}"
+                  echo "KYUA_SRCDIR=${GITHUB_WORKSPACE}/kyua-src" >> "${GITHUB_ENV}"
+                  echo "KYUA_OBJDIR=${GITHUB_WORKSPACE}/kyua-obj" >> "${GITHUB_ENV}"
+                  echo "KYUA_PREFIX=/usr/local" >> "${GITHUB_ENV}"
+                  echo "LUTOK_SRCDIR=${GITHUB_WORKSPACE}/lutok-src" >> "${GITHUB_ENV}"
+                  echo "LUTOK_OBJDIR=${GITHUB_WORKSPACE}/lutok-obj" >> "${GITHUB_ENV}"
+                  echo "NPROC=`getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 1`" >> "${GITHUB_ENV}"
+            - name: Build Environment Dump
+              run: |
+                  echo "ATF flag: ${{ matrix.enable-atf }}"
+                  echo "uname -a: $(uname -a)"
+                  echo "uname -m: $(uname -m)"
+                  echo "uname -p: $(uname -p)"
+                  echo "Build environment:"
+                  cat "${GITHUB_ENV}"
+            - name: Build and install ATF
+              if: matrix.enable-atf == '--enable-atf'
+              run: |
+                  set -x
+                  CFG_OPTS="--disable-dependency-tracking"
+                  CFG_OPTS="${CFG_OPTS} --prefix=${KYUA_PREFIX}"
+                  echo "Building lutok with ${CFG_OPTS}..."
+                  cd "${ATF_SRCDIR}"
+                  autoreconf -isv
+                  mkdir -p "${ATF_OBJDIR}"
+                  cd "${ATF_OBJDIR}"
+                  "${ATF_SRCDIR}/configure" ${CFG_OPTS}
+                  make -j${NPROC} all | tee atf-make-all.log
+                  sudo make install
+            - name: Build and Install Lutok
+              run: |
+                  CFG_OPTS="--disable-dependency-tracking"
+                  CFG_OPTS="${CFG_OPTS} --prefix=${KYUA_PREFIX}"
+                  echo "Building lutok with ${CFG_OPTS}..."
+                  cd "${LUTOK_SRCDIR}"
+                  autoreconf -isv -I/usr/local/share/aclocal
+                  mkdir -p "${LUTOK_OBJDIR}"
+                  cd "${LUTOK_OBJDIR}"
+                  "${LUTOK_SRCDIR}/configure" ${CFG_OPTS}
+                  make -j${NPROC} all | tee lutok-make-all.log
+                  cd "${LUTOK_OBJDIR}"
+                  sudo make install
+            - name: Build and Install Kyua
+              run: |
+                  # - Gather arguments.
+                  CFG_OPTS="--disable-dependency-tracking"
+                  CFG_OPTS="${CFG_OPTS} ${{ matrix.enable-atf }}"
+                  CFG_OPTS="${CFG_OPTS} --prefix=${KYUA_PREFIX}"
+                  if [ "x${{ matrix.enable-atf }}" = "x--enable-atf" ]; then
+                      CXXFLAGS="$CXXFLAGS $(pkgconf --cflags atf-c++)"
+                      LDFLAGS="$LDFLAGS $(pkgconf --libs-only-L atf-c++)"
+                  fi
+                  CXXFLAGS="${CXXFLAGS} $(pkgconf --cflags lutok)";
+                  LDFLAGS="${LDFLAGS} $(pkgconf --libs-only-L lutok)";
+                  # - Prep for running configure.
+                  mkdir -p "${KYUA_OBJDIR}" "${KYUA_HOME}"
+                  echo "syntax(2)" > "${KYUA_HOME}/kyua.conf"
+                  echo "unprivileged_user = 'nobody'" >> "${KYUA_HOME}/kyua.conf"
+                  # - Run autotools and configure.
+                  cd "${KYUA_SRCDIR}"
+                  autoreconf -isv -I/usr/local/share/aclocal
+                  cd "${KYUA_OBJDIR}"
+                  env CXXFLAGS="${CXXFLAGS}" \
+                      KYUA_CONFIG_FILE_FOR_CHECK="${KYUA_HOME}/kyua.conf" \
+                      LDFLAGS="${LDFLAGS}" \
+                      "${KYUA_SRCDIR}/configure" ${CFG_OPTS}
+                  # - Build
+                  make -j${NPROC} all | tee kyua-make-all.log
+                  # - Install
+                  sudo make install
+            - name: Test Kyua Setup (Ubuntu)
+              if: runner.os == 'Linux' && matrix.enable-atf == '--enable-atf'
+              run: |
+                  sudo mkdir -m 0755 -p /cores/
+                  sudo sysctl kernel.core_pattern="/cores/core.%e.%p"
+                  sudo ldconfig
+            - name: Test Kyua
+              if: matrix.enable-atf == '--enable-atf'
+              run: |
+                  set -x
+                  cd "${KYUA_OBJDIR}"
+                  # NB: the double quotes are intentional: `sudo -E` caused a ton of grief.
+                  sudo sh -c "export HOME=${KYUA_HOME} PATH=${PATH}; make installcheck"
+                  check_exit=$?
+                  sudo chmod -R a+rx "${KYUA_HOME}"
+                  if [ $check_exit -eq 0 ]; then
+                      echo "# ✅ All mandatory checks passed" >> $GITHUB_STEP_SUMMARY
+                  else
+                      echo "# ❌ Some checks failed" >> $GITHUB_STEP_SUMMARY
+                      echo "::error file=.github/workflows/build.yaml,line=173,endLine=173,title=Checks failed!::checks failed"
+                  fi
+                  #cd "${KYUA_PREFIX}/tests/kyua"
+                  #LOG_DB=$(find "${KYUA_HOME}" -name "*.db")
+                  #kyua report-html --results-file "${LOG_DB}" --output ${KYUA_OBJDIR}/html
+                  exit $check_exit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,242 @@
+---
+# GitHub action to compile and test kyua on supported platforms.
+#
+# Steps executed:
+# * Handle prerequisites
+#     * Install binary packages
+#     * Build packages from source (if needed).
+#     * Build
+#     * Install
+#     * Run tests
+#
+# On MacOS we build with:
+# * latest clang from brew (system provided clang lacks sanitizers).
+# * ld from system
+#
+env:
+    ATF_REPO: freebsd/atf
+    ATF_REF: atf-0.25
+    LUTOK_REPO: freebsd/lutok
+    LUTOK_REF: lutok-0.6.3
+
+name: build
+"on":
+    pull_request:
+        branches:
+            - master
+    push:
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    build-and-test:
+        env:
+            AR: ${{ matrix.llvm-bindir }}/llvm-ar
+            CC: ${{ matrix.llvm-bindir }}/clang
+            CPP: ${{ matrix.llvm-bindir }}/clang-cpp
+            CXX: ${{ matrix.llvm-bindir }}/clang++
+            NM: ${{ matrix.llvm-bindir }}/llvm-nm
+            OBJDUMP: ${{ matrix.llvm-bindir }}/llvm-objdump
+            RANLIB: ${{ matrix.llvm-bindir }}/llvm-ranlib
+            STRIP: ${{ matrix.llvm-bindir }}/llvm-strip
+            ATF_SRCDIR: ${{ github.workspace }}/atf-src
+            ATF_OBJDIR: ${{ github.workspace }}/atf-obj
+            KYUA_PREFIX: ${{ github.workspace }}/root
+            KYUA_SRCDIR: ${{ github.workspace }}/kyua-src
+            KYUA_OBJDIR: ${{ github.workspace }}/kyua-obj
+            LUTOK_SRCDIR: ${{ github.workspace }}/lutok-src
+            LUTOK_OBJDIR: ${{ github.workspace }}/lutok-obj
+        name: Build ${{ matrix.build-os }} ${{ matrix.compiler }}
+        runs-on: "${{ matrix.build-os }}"
+        strategy:
+            fail-fast: false
+            matrix:
+                build-os:
+                    - macos-latest
+                    - ubuntu-latest
+                include:
+                    # The macOS runner uses a homebrew provided compiler as the
+                    # system compiler lacks ASAN/LSAN/UBSAN support.
+                    - build-os: macos-latest
+                      compiler: clang-20
+                      env:
+                          # The coredump tests cause the macOS runner to
+                          # frequently timeout/fail due to ENOSPC issues. Skip
+                          # the tests until all of the issues can be worked
+                          # out.
+                          #
+                          # See this issue for more details:
+                          # https://github.com/actions/runner-images/issues/14678
+                          - RUN_COREDUMP_TESTS: false
+                      pkgs:
+                          - atf
+                          - autoconf
+                          - automake
+                          - libtool
+                          - llvm@20
+                          # This is required when
+                          # `build-dependencies-from-source == yes`:
+                          # - lua
+                          - lutok
+                          - pkgconf
+                          - sqlite
+                      llvm-bindir: /opt/homebrew/opt/llvm@20/bin
+                      build-dependencies-from-source: false
+                    - build-os: ubuntu-latest
+                      compiler: clang-18
+                      env:
+                          - RUN_COREDUMP_TESTS: true
+                      pkgs:
+                          - autoconf
+                          - automake
+                          - clang-18
+                          - libtool
+                          - lua5.4
+                          - liblua5.4-dev
+                          - pkgconf
+                          - libsqlite3-dev
+                      llvm-bindir: /usr/lib/llvm-18/bin
+                      build-dependencies-from-source: true
+
+        steps:
+            - name: Install base dependencies (macOS)
+              if: runner.os == 'macOS'
+              run: |
+                  brew update --quiet || true
+                  brew install -q ${{ join(matrix.pkgs, ' ') }}
+                  brew cleanup --scrub
+                  brew list -1
+                  rm -Rf "$(brew --cache)"
+
+            - name: Install base dependencies (Ubuntu)
+              if: runner.os == 'Linux'
+              run: |
+                  sudo apt update --quiet
+                  sudo apt --quiet -y --no-install-suggests \
+                      --no-install-recommends install \
+                      ${{ join(matrix.pkgs, ' ') }} \
+            - name: Checking out source (ATF)
+              if: ${{ matrix.build-dependencies-from-source }}
+              uses: actions/checkout@v4
+              with:
+                  repository: "${{ env.ATF_REPO }}"
+                  ref: "${{ env.ATF_REF }}"
+                  # Same as `ATF_SRCDIR`.
+                  path: "${{ github.workspace }}/atf-src"
+            - name: Checking out source (Lutok)
+              if: ${{ matrix.build-dependencies-from-source }}
+              uses: actions/checkout@v4
+              with:
+                  repository: "${{ env.LUTOK_REPO }}"
+                  ref: "${{ env.LUTOK_REF }}"
+                  # Same as `LUTOK_SRCDIR`.
+                  path: "${{ github.workspace }}/lutok-src"
+            - name: Checking out source (Kyua)
+              uses: actions/checkout@v4
+              with:
+                  # Same as `KYUA_SRCDIR`.
+                  path: "${{ github.workspace }}/kyua-src"
+            - name: Build Environment Dump
+              run: |
+                  echo "uname -a: $(uname -a)"
+                  echo "uname -m: $(uname -m)"
+                  echo "uname -p: $(uname -p)"
+
+            - name: Distcheck Environment Setup (common)
+              run: |
+                  sudo mkdir -p /cores
+                  sudo chmod 1777 /cores
+
+            - name: Distcheck Environment Setup (Ubuntu)
+              if: runner.os == 'Linux'
+              run: |
+                  sudo sh -c \
+                      'echo "/cores/core.%p" > /proc/sys/kernel/core_pattern'
+                  sudo ldconfig
+
+            - name: Distcheck Environment Setup (macOS)
+              if: runner.os == 'macOS'
+              run: |
+                  if [ "$(sysctl -n kern.coredump)" != 0 ]; then
+                      echo "Coredumps enabled on runner"
+                      df -h "$(dirname "$(sysctl -n kern.corefile)")"
+                      # sudo sysctl -w kern.corefile="/cores/core.%P"
+                  fi
+
+            # yamllint disable rule:line-length
+            - name: Build and install ATF and Lutok
+              if: ${{ matrix.build-dependencies-from-source }}
+              run: |
+                  export PREFIX="${KYUA_PREFIX}"
+                  export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
+
+                  cd "${ATF_SRCDIR}"
+                  "${KYUA_SRCDIR}/admin/ci-build/00_build_and_install_atf.sh"
+                  rm -Rf "${ATF_SRCDIR}"
+
+                  cd "${LUTOK_SRCDIR}"
+                  "${KYUA_SRCDIR}/admin/ci-build/00_build_and_install_lutok.sh"
+                  rm -Rf "${LUTOK_SRCDIR}"
+
+            # yamllint enable rule:line-length
+            - name: Configure
+              run: |
+                  export PREFIX="${KYUA_PREFIX}"
+                  export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
+                  CFG_ARGS="--enable-atf --enable-developer"
+                  for i in ${{ join(matrix.sanitize, ' ') }}; do
+                      CFG_ARGS="${CFG_ARGS} --enable-${i}"
+                  done
+                  cd "${KYUA_SRCDIR}"
+                  admin/ci-build/01_configure.sh ${CFG_ARGS}
+
+            - name: Distcheck (builds and tests)
+              run: |
+                  export PREFIX="${KYUA_PREFIX}"
+                  export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
+                  CFG_ARGS="--enable-atf --enable-developer"
+                  for i in ${{ join(matrix.sanitize, ' ') }}; do
+                      CFG_ARGS="${CFG_ARGS} --enable-${i}"
+                  done
+
+                  # export AS_ROOT=yes
+                  # export UNPRIVILEGED_USER=yes
+                  export RUN_COREDUMP_TESTS="${{ env.RUN_COREDUMP_TESTS }}"
+
+                  cd "${KYUA_SRCDIR}"
+                  env "EXTRA_DISTCHECK_CONFIGURE_ARGS=${CFG_ARGS}" \
+                      ./admin/ci-build/02_distcheck.sh
+
+            - name: Gather/Archive Logs and Reports
+              run: |
+                  REPORTS_DIR="${KYUA_OBJDIR}/reports"
+                  mkdir -p "${REPORTS_DIR}"
+                  (
+                    cd "${REPORTS_DIR}"
+                    mkdir -p build_logs
+                    # Gather the distcheck failure log if the target failed.
+                    # It's easier to ignore the failure than create yet another
+                    # conditional variable step.
+                    cp -a "${KYUA_SRCDIR}"/kyua-*/_build/sub/*.log build_logs/ \
+                        2>/dev/null || true
+                    # Include the raw kyua logs.
+                    cp -a ~/.kyua/logs kyua_logs
+                    # Include the raw kyua results DBs.
+                    cp -a ~/.kyua/store kyua_store
+                  )
+                  # Create an archive of the reports.
+                  job_name_encoded=$(echo "${JOB_NAME}" | tr ' ' '_')
+                  tar -cvf "kyua-test-reports-${job_name_encoded}.tar" \
+                      -C "${REPORTS_DIR}" .
+              if: ${{ ! cancelled() }}
+            - name: Archive Build Artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: Test Report for ${{ env.JOB_NAME }}
+                  path: kyua-test-reports-*.tar
+                  compression-level: 0
+                  retention-days: 10
+                  overwrite: true
+              if: ${{ ! cancelled() }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -116,11 +116,17 @@ installcheck-kyua:
 	cd $(pkgtestsdir) && $(INSTALLCHECK_ENVIRONMENT) $(TESTS_ENVIRONMENT) \
 	    kyua --config='$(KYUA_CONFIG_FILE_FOR_CHECK)' test \
 	    || failed=yes; \
+	cd $(pkgtestsdir) && $(INSTALLCHECK_ENVIRONMENT) $(TESTS_ENVIRONMENT) \
+	    kyua --config='$(KYUA_CONFIG_FILE_FOR_CHECK)' report \
+	    --verbose --results-filter=broken,failed; \
+	if [ -n "$$JUNIT_OUTPUT" ]; then \
+	    cd $(pkgtestsdir) && $(TESTS_ENVIRONMENT) \
+		    $(KYUA) --config='$(KYUA_CONFIG_FILE_FOR_CHECK)' \
+		    report-junit --output="$$JUNIT_OUTPUT"; \
+	    sed -i '.orig' 's/encoding="iso-8859-1"/encoding="utf-8"/' "$$JUNIT_OUTPUT"; \
+	    rm -f "$$JUNIT_OUTPUT.orig"; \
+	fi; \
 	if [ "$${failed}" = yes ]; then \
-	    cd $(pkgtestsdir) && $(INSTALLCHECK_ENVIRONMENT) \
-	        $(TESTS_ENVIRONMENT) \
-	        kyua --config='$(KYUA_CONFIG_FILE_FOR_CHECK)' report \
-	        --verbose --results-filter=broken,failed; \
 	    exit 1; \
 	fi
 

--- a/admin/ci-build/00_build_and_install_atf.sh
+++ b/admin/ci-build/00_build_and_install_atf.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enji Cooper.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Step 0.a: build and install ATF.
+
+set -eux
+
+: "${PREFIX=/usr/local}"
+
+autoreconf_args="-isv"
+if [ -d "${PREFIX}/share/aclocal" ]; then
+    autoreconf_args="${autoreconf_args} -I${PREFIX}/share/aclocal"
+fi
+# shellcheck disable=SC2086
+autoreconf ${autoreconf_args}
+
+# Don't enable dev mode.
+f="--disable-developer --prefix=${PREFIX} $@"
+# shellcheck disable=SC2086
+if ! ./configure ${f}; then
+    cat config.log || true
+    exit 1
+fi
+
+make all
+make install
+make clean
+
+# vim: syntax=sh:expandtab:shiftwidth=4:softtabstop=4

--- a/admin/ci-build/00_build_and_install_lutok.sh
+++ b/admin/ci-build/00_build_and_install_lutok.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enji Cooper.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Step 0.b: build and install lutok.
+
+set -eux
+
+: "${PREFIX=/usr/local}"
+
+autoreconf_args="-isv"
+if [ -d "${PREFIX}/share/aclocal" ]; then
+    autoreconf_args="${autoreconf_args} -I${PREFIX}/share/aclocal"
+fi
+# shellcheck disable=SC2086
+autoreconf ${autoreconf_args}
+
+# Don't enable dev mode/build the tests.
+f="--disable-atf --disable-developer --prefix=${PREFIX} $@"
+# shellcheck disable=SC2086
+if ! ./configure ${f}; then
+    cat config.log || true
+    exit 1
+fi
+
+make all
+make install
+make clean
+
+# vim: syntax=sh:expandtab:shiftwidth=4:softtabstop=4

--- a/admin/ci-build/00_prepare_freebsd_image.sh
+++ b/admin/ci-build/00_prepare_freebsd_image.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Step 0: Prepare the FreeBSD VM image for use.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+set -eux
+
+VERSION_MAJOR="$(uname -r | sed -Ee 's/\..+//')"
+if [ "${VERSION_MAJOR}" != 14 ]; then
+    exit 0
+fi
+
+# NO_CHECK_STYLE_BEGIN
+pkgbasify_sha256="7f3a4d514c46d03ad52d6689b621f4971ce85db42b1a41cabb18913e593357ad"
+pkgbasify_url="https://github.com/FreeBSDFoundation/pkgbasify/raw/refs/tags/v1.1.0/pkgbasify.lua"
+# NO_CHECK_STYLE_END
+pkgbasify_script="pkgbasify.lua"
+fetch -o "${pkgbasify_script}" "${pkgbasify_url}"
+chmod +x "${pkgbasify_script}"
+sha256 -c "${pkgbasify_sha256}" "${pkgbasify_script}"
+pkg update
+pkg upgrade -y pkg
+yes y | "./${pkgbasify_script}" --force
+
+# vim: syntax=sh:expandtab:shiftwidth=4:softtabstop=4

--- a/admin/ci-build/01_configure.sh
+++ b/admin/ci-build/01_configure.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enji Cooper.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Step 1: run autoconf/configure so the remaining of the build/test steps can
+# be completed.
+#
+# Splitting off this step allows any configure issues to be found quickly and
+# triaged more effectively.
+
+autoreconf_args="-isv"
+: "${PREFIX=/usr/local}"
+if [ -d ${PREFIX}/share/aclocal ]; then
+    autoreconf_args="${autoreconf_args} -I${PREFIX}/share/aclocal"
+fi
+# shellcheck disable=SC2086
+autoreconf ${autoreconf_args}
+
+# shellcheck disable=SC2086
+if ! ./configure $*; then
+    cat config.log || true
+    exit 1
+fi
+
+# vim: syntax=sh:expandtab:shiftwidth=4:softtabstop=4

--- a/admin/ci-build/02_distcheck.sh
+++ b/admin/ci-build/02_distcheck.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enji Cooper.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Step 2: run `make distcheck`.
+#
+# `make distcheck` builds the tests, runs them, and subsequently performs a
+# style check on the code.
+
+set -eux
+
+: "${AS_ROOT=no}"
+: "${CC=cc}"
+: "${CXX=c++}"
+: "${EXTRA_DISTCHECK_CONFIGURE_ARGS=}"
+: "${RUN_COREDUMP_TESTS:=false}"
+: "${UNPRIVILEGED_USER:=no}"
+
+NPROC=$(nproc 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 1)
+
+f=
+# Is this being run in a git clone, or with a release artifact? If the former,
+# automatically enable developer mode.
+if git rev-parse --is-inside-work-tree; then
+    f="${f} --enable-developer"
+fi
+if [ -n "${EXTRA_DISTCHECK_CONFIGURE_ARGS:-}" ]; then
+    f="${f} ${EXTRA_DISTCHECK_CONFIGURE_ARGS}"
+fi
+
+kyua_conf="$(realpath "$(mktemp kyuaconf-XXXXXXXX)")"
+trap 'rm -f "${kyua_conf}"' EXIT INT TERM
+
+sudo=
+
+cat >"${kyua_conf}" <<EOF
+syntax(2)
+
+-- We do not know how many CPUs the test machine has.  However, parallelizing
+-- the execution of our tests to _any_ degree speeds up the time it takes to
+-- complete a test run because many of our tests are blocking.
+parallelism = 4
+
+test_suites.kyua.run_coredump_tests = "${RUN_COREDUMP_TESTS}"
+EOF
+
+sudo=
+if [ "${AS_ROOT}" = yes ]; then
+    sudo="sudo -EH"
+fi
+if [ "${UNPRIVILEGED_USER}" = "yes" ]; then
+    echo "unprivileged_user = 'nobody'" >>"${kyua_conf}"
+fi
+${sudo} env PATH="${PATH}" make distcheck -j"${NPROC}" \
+    DISTCHECK_CONFIGURE_FLAGS="${f}" \
+    KYUA_CONFIG_FILE_FOR_CHECK="${kyua_conf}"
+
+# vim: syntax=sh:expandtab:shiftwidth=4:softtabstop=4:textwidth=80


### PR DESCRIPTION
This proposed GitHub Actions workflow file runs tests on macOS and Ubuntu Linux, similar to what was proposed in https://github.com/freebsd/atf/pull/93 .

The delta between this change and the one being made in ATF mostly relates to the additional package dependencies, e.g., with and without ATF.

Kyua is built from scratch because of issues with dependent packages and runtime linker collisions on both macOS and Ubuntu. The binary package versions are built against a different version of Lutok, ergo they can have runtime linker collisions.