### PR TITLE
Pass unprivileged user config prop to ATF using all known names

### DIFF
--- a/engine/scheduler.cpp
+++ b/engine/scheduler.cpp
@@ -1632,7 +1632,10 @@ scheduler::generate_config(const config::tree& user_config,
     if (user_config.is_set("unprivileged_user")) {
         const passwd::user& user =
             user_config.lookup< engine::user_node >("unprivileged_user");
+	// The property is duplicated using both ATF and Kyua naming styles
+	// for better UX.
         props["unprivileged-user"] = user.name;
+        props["unprivileged_user"] = user.name;
     }
 
     return props;

--- a/engine/scheduler_test.cpp
+++ b/engine/scheduler_test.cpp
@@ -1192,6 +1192,7 @@ ATF_TEST_CASE_BODY(generate_config__some_matches)
 
     config::properties_map exp_props;
     exp_props["unprivileged-user"] = "nobody";
+    exp_props["unprivileged_user"] = "nobody";
     exp_props["var1"] = "value 1";
 
     ATF_REQUIRE_EQ(exp_props,

--- a/integration/helpers/config.cpp
+++ b/integration/helpers/config.cpp
@@ -34,12 +34,16 @@
 ATF_TEST_CASE(get_variable);
 ATF_TEST_CASE_HEAD(get_variable)
 {
+    const char* varname = ::getenv("CONFIG_VAR_NAME");
+    if (varname == NULL) {
+        varname = "the-variable";
+    }
     const char* output = ::getenv("CONFIG_VAR_FILE");
     if (output == NULL) {
-        set_md_var("require.config", "the-variable");
+        set_md_var("require.config", varname);
     } else {
-        if (has_config_var("the-variable")) {
-            atf::utils::create_file(output, get_config_var("the-variable") +
+        if (has_config_var(varname)) {
+            atf::utils::create_file(output, get_config_var(varname) +
                                     std::string("\n"));
         } else {
             atf::utils::create_file(output, "NOT DEFINED\n");


### PR DESCRIPTION
```
Kyua and ATF speak different naming styles. In this case, the
unprivileged user property can be named with underscore on the Kyua
side, and with a hyphen on the ATF side. Sometimes it is not obvious
which style should be used in which situation. For instance, a test case
may require this configuration property being set using require.config.
Also, a test case may want to read the property using something like
atf_tc_get_config_var(). Which names should be used in these cases?
From the perspective of the original code, it is expected to be this:
    require.config unprivileged-user
    atf_tc_get_config_var(tc, "unprivileged-user")

But, as long as Kyua is the main interface, its users expect to work
with kyua.conf(5), which says that it must be named as unprivileged_user
(with underscore). As a result, test authors tend to do this instead:
    require.config unprivileged_user
    atf_tc_get_config_var(tc, "unprivileged_user")

Kyua already has hacks to understand both unprivileged_user and
unprivileged-user coming from require.config. And this patch covers the
missing second part -- make Kyua pass both names back to ATF as two
identical configuration properties named different ways.
```