### PR TITLE
Switch from std::auto_ptr<> to std::unique_ptr<>

### DIFF
--- a/cli/cmd_report.cpp
+++ b/cli/cmd_report.cpp
@@ -404,7 +404,7 @@ cmd_report::run(cmdline::ui* ui,
                 const cmdline::parsed_cmdline& cmdline,
                 const config::tree& /* user_config */)
 {
-    std::auto_ptr< std::ostream > output = utils::open_ostream(
+    std::unique_ptr< std::ostream > output = utils::open_ostream(
         cmdline.get_option< cmdline::path_option >("output"));
 
     const fs::path results_file = layout::find_results(

--- a/cli/cmd_report_junit.cpp
+++ b/cli/cmd_report_junit.cpp
@@ -77,7 +77,7 @@ cmd_report_junit::run(cmdline::ui* /* ui */,
     const fs::path results_file = layout::find_results(
         results_file_open(cmdline));
 
-    std::auto_ptr< std::ostream > output = utils::open_ostream(
+    std::unique_ptr< std::ostream > output = utils::open_ostream(
         cmdline.get_option< cmdline::path_option >("output"));
 
     drivers::report_junit_hooks hooks(*output.get());

--- a/cli/common.hpp
+++ b/cli/common.hpp
@@ -68,7 +68,7 @@ typedef utils::cmdline::base_command< utils::config::tree > cli_command;
 
 
 /// Scoped, strictly owned pointer to a cli_command.
-typedef std::auto_ptr< cli_command > cli_command_ptr;
+typedef std::unique_ptr< cli_command > cli_command_ptr;
 
 
 /// Collection of result types.

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -198,7 +198,7 @@ safe_main(cmdline::ui* ui, int argc, const char* const argv[],
     commands.insert(new cli::cmd_report_junit(), "Reporting");
 
     if (mock_command.get() != NULL)
-        commands.insert(mock_command);
+        commands.insert(std::move(mock_command));
 
     const cmdline::parsed_cmdline cmdline = cmdline::parse(argc, argv, options);
 
@@ -277,7 +277,7 @@ cli::main(cmdline::ui* ui, const int argc, const char* const* const argv,
           cli_command_ptr mock_command)
 {
     try {
-        const int exit_code = safe_main(ui, argc, argv, mock_command);
+        const int exit_code = safe_main(ui, argc, argv, std::move(mock_command));
 
         // Codes above 1 are reserved to report conditions captured as
         // exceptions below.

--- a/engine/config.cpp
+++ b/engine/config.cpp
@@ -141,7 +141,7 @@ public:
 config::detail::base_node*
 engine::user_node::deep_copy(void) const
 {
-    std::auto_ptr< user_node > new_node(new user_node());
+    std::unique_ptr< user_node > new_node(new user_node());
     new_node->_value = _value;
     return new_node.release();
 }

--- a/engine/scheduler.cpp
+++ b/engine/scheduler.cpp
@@ -1567,12 +1567,12 @@ scheduler::scheduler_handle::debug_test(
     // file, waiting for further output to appear... as this only works on pipes
     // or sockets.  We need a better interface for this whole thing.
     {
-        std::auto_ptr< std::ostream > output = utils::open_ostream(
+        std::unique_ptr< std::ostream > output = utils::open_ostream(
             stdout_target);
         *output << utils::read_file(result_handle->stdout_file());
     }
     {
-        std::auto_ptr< std::ostream > output = utils::open_ostream(
+        std::unique_ptr< std::ostream > output = utils::open_ostream(
             stderr_target);
         *output << utils::read_file(result_handle->stderr_file());
     }

--- a/model/metadata.cpp
+++ b/model/metadata.cpp
@@ -76,7 +76,7 @@ public:
     virtual base_node*
     deep_copy(void) const
     {
-        std::auto_ptr< bytes_node > new_node(new bytes_node());
+        std::unique_ptr< bytes_node > new_node(new bytes_node());
         new_node->_value = _value;
         return new_node.release();
     }
@@ -106,7 +106,7 @@ public:
     virtual base_node*
     deep_copy(void) const
     {
-        std::auto_ptr< delta_node > new_node(new delta_node());
+        std::unique_ptr< delta_node > new_node(new delta_node());
         new_node->_value = _value;
         return new_node.release();
     }
@@ -166,7 +166,7 @@ class user_node : public config::string_node {
     virtual base_node*
     deep_copy(void) const
     {
-        std::auto_ptr< user_node > new_node(new user_node());
+        std::unique_ptr< user_node > new_node(new user_node());
         new_node->_value = _value;
         return new_node.release();
     }
@@ -197,7 +197,7 @@ class paths_set_node : public config::base_set_node< fs::path > {
     virtual base_node*
     deep_copy(void) const
     {
-        std::auto_ptr< paths_set_node > new_node(new paths_set_node());
+        std::unique_ptr< paths_set_node > new_node(new paths_set_node());
         new_node->_value = _value;
         return new_node.release();
     }

--- a/model/metadata.hpp
+++ b/model/metadata.hpp
@@ -95,7 +95,7 @@ class metadata_builder : utils::noncopyable {
     struct impl;
 
     /// Pointer to the shared internal implementation.
-    std::auto_ptr< impl > _pimpl;
+    std::unique_ptr< impl > _pimpl;
 
 public:
     metadata_builder(void);

--- a/model/test_program.hpp
+++ b/model/test_program.hpp
@@ -87,7 +87,7 @@ class test_program_builder : utils::noncopyable {
     struct impl;
 
     /// Pointer to the shared internal implementation.
-    std::auto_ptr< impl > _pimpl;
+    std::unique_ptr< impl > _pimpl;
 
 public:
     test_program_builder(const std::string&, const utils::fs::path&,

--- a/os/freebsd/utils/jail.cpp
+++ b/os/freebsd/utils/jail.cpp
@@ -213,7 +213,7 @@ jail::create(const std::string& jail_name,
     av.push_back("persist");
 
     // invoke jail
-    std::auto_ptr< process::child > child = child::fork_capture(
+    std::unique_ptr< process::child > child = child::fork_capture(
         run(fs::path("/usr/sbin/jail"), av));
     process::status status = child->wait();
 
@@ -288,7 +288,7 @@ jail::remove(const std::string& jail_name)
     av.push_back(jail_name);
 
     // invoke jail
-    std::auto_ptr< process::child > child = child::fork_capture(
+    std::unique_ptr< process::child > child = child::fork_capture(
         run(fs::path("/usr/sbin/jail"), av));
     process::status status = child->wait();
 

--- a/utils/auto_array.hpp
+++ b/utils/auto_array.hpp
@@ -66,8 +66,8 @@ public:
 
 /// A simple smart pointer for arrays providing strict ownership semantics.
 ///
-/// This class is the counterpart of std::auto_ptr for arrays.  The semantics of
-/// the API of this class are the same as those of std::auto_ptr.
+/// This class is the counterpart of std::unique_ptr for arrays.  The semantics of
+/// the API of this class are the same as those of std::unique_ptr.
 ///
 /// The wrapped pointer must be NULL or must have been allocated using operator
 /// new[].

--- a/utils/cmdline/commands_map.hpp
+++ b/utils/cmdline/commands_map.hpp
@@ -72,7 +72,7 @@ public:
     ~commands_map(void);
 
     /// Scoped, strictly-owned pointer to a command from this map.
-    typedef typename std::auto_ptr< BaseCommand > command_ptr;
+    typedef typename std::unique_ptr< BaseCommand > command_ptr;
     void insert(command_ptr, const std::string& = "");
     void insert(BaseCommand*, const std::string& = "");
 

--- a/utils/config/lua_module_test.cpp
+++ b/utils/config/lua_module_test.cpp
@@ -67,7 +67,7 @@ public:
     virtual base_node*
     deep_copy(void) const
     {
-        std::auto_ptr< custom_node > new_node(new custom_node());
+        std::unique_ptr< custom_node > new_node(new custom_node());
         new_node->_value = _value;
         return new_node.release();
     }

--- a/utils/config/nodes.cpp
+++ b/utils/config/nodes.cpp
@@ -110,7 +110,7 @@ config::detail::inner_node::combine_children_into(
             continue;
         }
 
-        std::auto_ptr< base_node > new_node;
+        std::unique_ptr< base_node > new_node;
 
         children_map::const_iterator iter2 = c2.find(name);
         if (iter2 == c2.end()) {
@@ -296,7 +296,7 @@ config::detail::static_inner_node::static_inner_node(void) :
 config::detail::base_node*
 config::detail::static_inner_node::deep_copy(void) const
 {
-    std::auto_ptr< inner_node > new_node(new static_inner_node());
+    std::unique_ptr< inner_node > new_node(new static_inner_node());
     copy_into(new_node.get());
     return new_node.release();
 }
@@ -314,7 +314,7 @@ config::detail::base_node*
 config::detail::static_inner_node::combine(const tree_key& key,
                                            const base_node* other) const
 {
-    std::auto_ptr< inner_node > new_node(new static_inner_node());
+    std::unique_ptr< inner_node > new_node(new static_inner_node());
     combine_into(key, other, new_node.get());
     return new_node.release();
 }
@@ -377,7 +377,7 @@ config::detail::dynamic_inner_node::dynamic_inner_node(void) :
 config::detail::base_node*
 config::detail::dynamic_inner_node::deep_copy(void) const
 {
-    std::auto_ptr< inner_node > new_node(new dynamic_inner_node());
+    std::unique_ptr< inner_node > new_node(new dynamic_inner_node());
     copy_into(new_node.get());
     return new_node.release();
 }
@@ -395,7 +395,7 @@ config::detail::base_node*
 config::detail::dynamic_inner_node::combine(const tree_key& key,
                                             const base_node* other) const
 {
-    std::auto_ptr< inner_node > new_node(new dynamic_inner_node());
+    std::unique_ptr< inner_node > new_node(new dynamic_inner_node());
     combine_into(key, other, new_node.get());
     return new_node.release();
 }
@@ -441,7 +441,7 @@ config::leaf_node::combine(const detail::tree_key& key,
 config::detail::base_node*
 config::bool_node::deep_copy(void) const
 {
-    std::auto_ptr< bool_node > new_node(new bool_node());
+    std::unique_ptr< bool_node > new_node(new bool_node());
     new_node->_value = _value;
     return new_node.release();
 }
@@ -480,7 +480,7 @@ config::bool_node::set_lua(lutok::state& state, const int value_index)
 config::detail::base_node*
 config::int_node::deep_copy(void) const
 {
-    std::auto_ptr< int_node > new_node(new int_node());
+    std::unique_ptr< int_node > new_node(new int_node());
     new_node->_value = _value;
     return new_node.release();
 }
@@ -532,7 +532,7 @@ config::positive_int_node::validate(const value_type& new_value) const
 config::detail::base_node*
 config::string_node::deep_copy(void) const
 {
-    std::auto_ptr< string_node > new_node(new string_node());
+    std::unique_ptr< string_node > new_node(new string_node());
     new_node->_value = _value;
     return new_node.release();
 }
@@ -571,7 +571,7 @@ config::string_node::set_lua(lutok::state& state, const int value_index)
 config::detail::base_node*
 config::strings_set_node::deep_copy(void) const
 {
-    std::auto_ptr< strings_set_node > new_node(new strings_set_node());
+    std::unique_ptr< strings_set_node > new_node(new strings_set_node());
     new_node->_value = _value;
     return new_node.release();
 }

--- a/utils/config/parser.hpp
+++ b/utils/config/parser.hpp
@@ -66,7 +66,7 @@ public:
 
 private:
     /// Pointer to the internal implementation.
-    std::auto_ptr< impl > _pimpl;
+    std::unique_ptr< impl > _pimpl;
 
     /// Hook to initialize the tree keys before reading the file.
     ///

--- a/utils/config/tree_test.cpp
+++ b/utils/config/tree_test.cpp
@@ -76,7 +76,7 @@ public:
     virtual base_node*
     deep_copy(void) const
     {
-        std::auto_ptr< wrapped_int_node > new_node(new wrapped_int_node());
+        std::unique_ptr< wrapped_int_node > new_node(new wrapped_int_node());
         new_node->_value = _value;
         return new_node.release();
     }

--- a/utils/format/formatter.cpp
+++ b/utils/format/formatter.cpp
@@ -118,7 +118,7 @@ to_int(const std::string& format, const std::string& str, const char* what)
 static std::ostringstream*
 new_ostringstream(const std::string& format)
 {
-    std::auto_ptr< std::ostringstream > output(new std::ostringstream());
+    std::unique_ptr< std::ostringstream > output(new std::ostringstream());
 
     if (format.length() <= 2) {
         // If the format is empty, we create a new stream so that we don't have

--- a/utils/fs/directory.cpp
+++ b/utils/fs/directory.cpp
@@ -129,7 +129,7 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
     ::DIR* _dirp;
 
     /// Custom representation of the directory entry.
-    std::auto_ptr< directory_entry > _entry;
+    std::unique_ptr< directory_entry > _entry;
 
     /// Constructs an iterator pointing to the "end" of the directory.
     impl(void) : _path("invalid-directory-entry"), _dirp(NULL)

--- a/utils/logging/operations.cpp
+++ b/utils/logging/operations.cpp
@@ -105,7 +105,7 @@ struct global_state {
     std::vector< std::pair< logging::level, std::string > > backlog;
 
     /// Stream to the currently open log file.
-    std::auto_ptr< std::ostream > logfile;
+    std::unique_ptr< std::ostream > logfile;
 
     global_state() :
         log_level(logging::level_debug),

--- a/utils/process/child.cpp
+++ b/utils/process/child.cpp
@@ -65,7 +65,7 @@ struct child::impl : utils::noncopyable {
     pid_t _pid;
 
     /// The input stream for the process' stdout and stderr.  May be NULL.
-    std::auto_ptr< process::ifdstream > _output;
+    std::unique_ptr< process::ifdstream > _output;
 
     /// Initializes private implementation data.
     ///
@@ -192,7 +192,7 @@ process::child::~child(void)
 /// noncopyable.  In the case of the child, a NULL pointer.
 ///
 /// \throw process::system_error If the calls to pipe(2) or fork(2) fail.
-std::auto_ptr< process::child >
+std::unique_ptr< process::child >
 process::child::fork_capture_aux(void)
 {
     std::cout.flush();
@@ -202,7 +202,7 @@ process::child::fork_capture_aux(void)
     if (detail::syscall_pipe(fds) == -1)
         throw process::system_error("pipe(2) failed", errno);
 
-    std::auto_ptr< signals::interrupts_inhibiter > inhibiter(
+    std::unique_ptr< signals::interrupts_inhibiter > inhibiter(
         new signals::interrupts_inhibiter);
     pid_t pid = detail::syscall_fork();
     if (pid == -1) {
@@ -223,13 +223,13 @@ process::child::fork_capture_aux(void)
             std::cerr << F("Failed to set up subprocess: %s\n") % e.what();
             std::abort();
         }
-        return std::auto_ptr< process::child >(NULL);
+        return std::unique_ptr< process::child >(NULL);
     } else {
         ::close(fds[1]);
         LD(F("Spawned process %s: stdout and stderr inherited") % pid);
         signals::add_pid_to_kill(pid);
         inhibiter.reset(NULL);  // Unblock signals.
-        return std::auto_ptr< process::child >(
+        return std::unique_ptr< process::child >(
             new process::child(new impl(pid, new process::ifdstream(fds[0]))));
     }
 }
@@ -252,14 +252,14 @@ process::child::fork_capture_aux(void)
 /// noncopyable.  In the case of the child, a NULL pointer.
 ///
 /// \throw process::system_error If the call to fork(2) fails.
-std::auto_ptr< process::child >
+std::unique_ptr< process::child >
 process::child::fork_files_aux(const fs::path& stdout_file,
                                const fs::path& stderr_file)
 {
     std::cout.flush();
     std::cerr.flush();
 
-    std::auto_ptr< signals::interrupts_inhibiter > inhibiter(
+    std::unique_ptr< signals::interrupts_inhibiter > inhibiter(
         new signals::interrupts_inhibiter);
     pid_t pid = detail::syscall_fork();
     if (pid == -1) {
@@ -284,13 +284,13 @@ process::child::fork_files_aux(const fs::path& stdout_file,
             std::cerr << F("Failed to set up subprocess: %s\n") % e.what();
             std::abort();
         }
-        return std::auto_ptr< process::child >(NULL);
+        return std::unique_ptr< process::child >(NULL);
     } else {
         LD(F("Spawned process %s: stdout=%s, stderr=%s") % pid % stdout_file %
            stderr_file);
         signals::add_pid_to_kill(pid);
         inhibiter.reset(NULL);  // Unblock signals.
-        return std::auto_ptr< process::child >(
+        return std::unique_ptr< process::child >(
             new process::child(new impl(pid, NULL)));
     }
 }
@@ -309,10 +309,10 @@ process::child::fork_files_aux(const fs::path& stdout_file,
 ///
 /// \throw process::system_error If the process cannot be spawned due to a
 ///     system call error.
-std::auto_ptr< process::child >
+std::unique_ptr< process::child >
 process::child::spawn_capture(const fs::path& program, const args_vector& args)
 {
-    std::auto_ptr< child > child = fork_capture_aux();
+    std::unique_ptr< child > child = fork_capture_aux();
     if (child.get() == NULL)
         exec(program, args);
     log_exec(program, args);
@@ -335,13 +335,13 @@ process::child::spawn_capture(const fs::path& program, const args_vector& args)
 ///
 /// \throw process::system_error If the process cannot be spawned due to a
 ///     system call error.
-std::auto_ptr< process::child >
+std::unique_ptr< process::child >
 process::child::spawn_files(const fs::path& program,
                             const args_vector& args,
                             const fs::path& stdout_file,
                             const fs::path& stderr_file)
 {
-    std::auto_ptr< child > child = fork_files_aux(stdout_file, stderr_file);
+    std::unique_ptr< child > child = fork_files_aux(stdout_file, stderr_file);
     if (child.get() == NULL)
         exec(program, args);
     log_exec(program, args);

--- a/utils/process/child.hpp
+++ b/utils/process/child.hpp
@@ -76,11 +76,11 @@ class child : noncopyable {
     struct impl;
 
     /// Pointer to the shared internal implementation.
-    std::auto_ptr< impl > _pimpl;
+    std::unique_ptr< impl > _pimpl;
 
-    static std::auto_ptr< child > fork_capture_aux(void);
+    static std::unique_ptr< child > fork_capture_aux(void);
 
-    static std::auto_ptr< child > fork_files_aux(const fs::path&,
+    static std::unique_ptr< child > fork_files_aux(const fs::path&,
                                                  const fs::path&);
 
     explicit child(impl *);
@@ -89,16 +89,16 @@ public:
     ~child(void);
 
     template< typename Hook >
-    static std::auto_ptr< child > fork_capture(Hook);
+    static std::unique_ptr< child > fork_capture(Hook);
     std::istream& output(void);
 
     template< typename Hook >
-    static std::auto_ptr< child > fork_files(Hook, const fs::path&,
+    static std::unique_ptr< child > fork_files(Hook, const fs::path&,
                                              const fs::path&);
 
-    static std::auto_ptr< child > spawn_capture(
+    static std::unique_ptr< child > spawn_capture(
         const fs::path&, const args_vector&);
-    static std::auto_ptr< child > spawn_files(
+    static std::unique_ptr< child > spawn_files(
         const fs::path&, const args_vector&, const fs::path&, const fs::path&);
 
     int pid(void) const;

--- a/utils/process/child.ipp
+++ b/utils/process/child.ipp
@@ -52,11 +52,11 @@ namespace process {
 /// \throw process::system_error If the process cannot be spawned due to a
 ///     system call error.
 template< typename Hook >
-std::auto_ptr< child >
+std::unique_ptr< child >
 child::fork_files(Hook hook, const fs::path& stdout_file,
                   const fs::path& stderr_file)
 {
-    std::auto_ptr< child > child = fork_files_aux(stdout_file, stderr_file);
+    std::unique_ptr< child > child = fork_files_aux(stdout_file, stderr_file);
     if (child.get() == NULL) {
         try {
             hook();
@@ -85,10 +85,10 @@ child::fork_files(Hook hook, const fs::path& stdout_file,
 /// \throw process::system_error If the process cannot be spawned due to a
 ///     system call error.
 template< typename Hook >
-std::auto_ptr< child >
+std::unique_ptr< child >
 child::fork_capture(Hook hook)
 {
-    std::auto_ptr< child > child = fork_capture_aux();
+    std::unique_ptr< child > child = fork_capture_aux();
     if (child.get() == NULL) {
         try {
             hook();

--- a/utils/process/child_test.cpp
+++ b/utils/process/child_test.cpp
@@ -292,7 +292,7 @@ do_inherit_test(const char* fork_stdout, const char* fork_stderr,
             ::close(fd);
         }
 
-        std::auto_ptr< process::child > child = process::child::fork_files(
+        std::unique_ptr< process::child > child = process::child::fork_files(
             child_simple_function< 123, 'Z' >,
             fs::path(fork_stdout), fs::path(fork_stderr));
         const process::status status = child->wait();
@@ -323,7 +323,7 @@ child__fork_capture__ok(Hook hook)
 {
     std::cout << "This unflushed message should not propagate to the child";
     std::cerr << "This unflushed message should not propagate to the child";
-    std::auto_ptr< process::child > child = process::child::fork_capture(hook);
+    std::unique_ptr< process::child > child = process::child::fork_capture(hook);
     std::cout.flush();
     std::cerr.flush();
 
@@ -365,7 +365,7 @@ ATF_TEST_CASE_BODY(child__fork_capture__ok_functor)
 ATF_TEST_CASE_WITHOUT_HEAD(child__fork_capture__catch_exceptions);
 ATF_TEST_CASE_BODY(child__fork_capture__catch_exceptions)
 {
-    std::auto_ptr< process::child > child = process::child::fork_capture(
+    std::unique_ptr< process::child > child = process::child::fork_capture(
         child_throw_exception);
 
     std::string message;
@@ -383,7 +383,7 @@ ATF_TEST_CASE_BODY(child__fork_capture__catch_exceptions)
 ATF_TEST_CASE_WITHOUT_HEAD(child__fork_capture__new_session);
 ATF_TEST_CASE_BODY(child__fork_capture__new_session)
 {
-    std::auto_ptr< process::child > child = process::child::fork_capture(
+    std::unique_ptr< process::child > child = process::child::fork_capture(
         child_check_own_session);
     const process::status status = child->wait();
     ATF_REQUIRE(status.exited());
@@ -411,7 +411,7 @@ ATF_TEST_CASE_BODY(child__fork_capture__fork_cannot_exit)
     const pid_t parent_pid = ::getpid();
     atf::utils::create_file("to-not-be-deleted", "");
 
-    std::auto_ptr< process::child > child = process::child::fork_capture(
+    std::unique_ptr< process::child > child = process::child::fork_capture(
         child_return);
     if (::getpid() != parent_pid) {
         // If we enter this clause, it is because the hook returned.
@@ -431,7 +431,7 @@ ATF_TEST_CASE_BODY(child__fork_capture__fork_cannot_unwind)
     const pid_t parent_pid = ::getpid();
     atf::utils::create_file("to-not-be-deleted", "");
     try {
-        std::auto_ptr< process::child > child = process::child::fork_capture(
+        std::unique_ptr< process::child > child = process::child::fork_capture(
             child_raise_exception< int, 123 >);
         const process::status status = child->wait();
         ATF_REQUIRE(status.signaled());
@@ -467,7 +467,7 @@ ATF_TEST_CASE_BODY(child__fork_files__ok_function)
     const fs::path file1("file1.txt");
     const fs::path file2("file2.txt");
 
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_simple_function< 15, 'Z' >, file1, file2);
     const process::status status = child->wait();
     ATF_REQUIRE(status.exited());
@@ -490,7 +490,7 @@ ATF_TEST_CASE_BODY(child__fork_files__ok_functor)
     atf::utils::create_file(filea.str(), "Initial stdout\n");
     atf::utils::create_file(fileb.str(), "Initial stderr\n");
 
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_simple_functor(16, "a functor"), filea, fileb);
     const process::status status = child->wait();
     ATF_REQUIRE(status.exited());
@@ -513,7 +513,7 @@ ATF_TEST_CASE_BODY(child__fork_files__ok_functor)
 ATF_TEST_CASE_WITHOUT_HEAD(child__fork_files__catch_exceptions);
 ATF_TEST_CASE_BODY(child__fork_files__catch_exceptions)
 {
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_throw_exception,
         fs::path("unused.out"), fs::path("stderr"));
 
@@ -528,7 +528,7 @@ ATF_TEST_CASE_BODY(child__fork_files__catch_exceptions)
 ATF_TEST_CASE_WITHOUT_HEAD(child__fork_files__new_session);
 ATF_TEST_CASE_BODY(child__fork_files__new_session)
 {
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_check_own_session,
         fs::path("unused.out"), fs::path("unused.err"));
     const process::status status = child->wait();
@@ -557,7 +557,7 @@ ATF_TEST_CASE_BODY(child__fork_files__fork_cannot_exit)
     const pid_t parent_pid = ::getpid();
     atf::utils::create_file("to-not-be-deleted", "");
 
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_return, fs::path("out"), fs::path("err"));
     if (::getpid() != parent_pid) {
         // If we enter this clause, it is because the hook returned.
@@ -577,7 +577,7 @@ ATF_TEST_CASE_BODY(child__fork_files__fork_cannot_unwind)
     const pid_t parent_pid = ::getpid();
     atf::utils::create_file("to-not-be-deleted", "");
     try {
-        std::auto_ptr< process::child > child = process::child::fork_files(
+        std::unique_ptr< process::child > child = process::child::fork_files(
             child_raise_exception< int, 123 >, fs::path("out"),
             fs::path("err"));
         const process::status status = child->wait();
@@ -615,7 +615,7 @@ ATF_TEST_CASE_WITHOUT_HEAD(child__fork_files__create_stdout_fail);
 ATF_TEST_CASE_BODY(child__fork_files__create_stdout_fail)
 {
     process::detail::syscall_open = open_fail< ENOENT >;
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_simple_function< 1, 'A' >, fs::path("raise-error"),
         fs::path("created"));
     const process::status status = child->wait();
@@ -630,7 +630,7 @@ ATF_TEST_CASE_WITHOUT_HEAD(child__fork_files__create_stderr_fail);
 ATF_TEST_CASE_BODY(child__fork_files__create_stderr_fail)
 {
     process::detail::syscall_open = open_fail< ENOENT >;
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_simple_function< 1, 'A' >, fs::path("created"),
         fs::path("raise-error"));
     const process::status status = child->wait();
@@ -650,7 +650,7 @@ ATF_TEST_CASE_BODY(child__spawn__absolute_path)
 
     const fs::path program = get_helpers(this);
     INV(program.is_absolute());
-    std::auto_ptr< process::child > child = process::child::spawn_files(
+    std::unique_ptr< process::child > child = process::child::spawn_files(
         program, args, fs::path("out"), fs::path("err"));
 
     const process::status status = child->wait();
@@ -669,7 +669,7 @@ ATF_TEST_CASE_BODY(child__spawn__relative_path)
     ATF_REQUIRE(::mkdir("root", 0755) != -1);
     ATF_REQUIRE(::symlink(get_helpers(this).c_str(), "root/helpers") != -1);
 
-    std::auto_ptr< process::child > child = process::child::spawn_files(
+    std::unique_ptr< process::child > child = process::child::spawn_files(
         fs::path("root/helpers"), args, fs::path("out"), fs::path("err"));
 
     const process::status status = child->wait();
@@ -687,7 +687,7 @@ ATF_TEST_CASE_BODY(child__spawn__basename_only)
 
     ATF_REQUIRE(::symlink(get_helpers(this).c_str(), "helpers") != -1);
 
-    std::auto_ptr< process::child > child = process::child::spawn_files(
+    std::unique_ptr< process::child > child = process::child::spawn_files(
         fs::path("helpers"), args, fs::path("out"), fs::path("err"));
 
     const process::status status = child->wait();
@@ -707,7 +707,7 @@ ATF_TEST_CASE_BODY(child__spawn__no_path)
 
     const fs::path helpers = get_helpers(this);
     utils::setenv("PATH", helpers.branch_path().c_str());
-    std::auto_ptr< process::child > child = process::child::spawn_capture(
+    std::unique_ptr< process::child > child = process::child::spawn_capture(
         fs::path(helpers.leaf_name()), args);
 
     std::string line;
@@ -725,7 +725,7 @@ ATF_TEST_CASE_WITHOUT_HEAD(child__spawn__no_args);
 ATF_TEST_CASE_BODY(child__spawn__no_args)
 {
     std::vector< std::string > args;
-    std::auto_ptr< process::child > child = process::child::spawn_capture(
+    std::unique_ptr< process::child > child = process::child::spawn_capture(
         get_helpers(this), args);
 
     std::string line;
@@ -746,7 +746,7 @@ ATF_TEST_CASE_BODY(child__spawn__some_args)
     args.push_back("print-args");
     args.push_back("foo");
     args.push_back("   bar baz ");
-    std::auto_ptr< process::child > child = process::child::spawn_capture(
+    std::unique_ptr< process::child > child = process::child::spawn_capture(
         get_helpers(this), args);
 
     std::string line;
@@ -772,7 +772,7 @@ ATF_TEST_CASE_WITHOUT_HEAD(child__spawn__missing_program);
 ATF_TEST_CASE_BODY(child__spawn__missing_program)
 {
     std::vector< std::string > args;
-    std::auto_ptr< process::child > child = process::child::spawn_capture(
+    std::unique_ptr< process::child > child = process::child::spawn_capture(
         fs::path("a/b/c"), args);
 
     std::string line;
@@ -790,7 +790,7 @@ ATF_TEST_CASE_BODY(child__spawn__missing_program)
 ATF_TEST_CASE_WITHOUT_HEAD(child__pid);
 ATF_TEST_CASE_BODY(child__pid)
 {
-    std::auto_ptr< process::child > child = process::child::fork_capture(
+    std::unique_ptr< process::child > child = process::child::fork_capture(
         child_write_pid);
 
     const int pid = child->pid();

--- a/utils/process/deadline_killer_test.cpp
+++ b/utils/process/deadline_killer_test.cpp
@@ -66,7 +66,7 @@ child_sleep(void)
 ATF_TEST_CASE_WITHOUT_HEAD(activation);
 ATF_TEST_CASE_BODY(activation)
 {
-    std::auto_ptr< process::child > child = process::child::fork_capture(
+    std::unique_ptr< process::child > child = process::child::fork_capture(
         child_sleep< 60 >);
 
     datetime::timestamp start = datetime::timestamp::now();
@@ -85,7 +85,7 @@ ATF_TEST_CASE_BODY(activation)
 ATF_TEST_CASE_WITHOUT_HEAD(no_activation);
 ATF_TEST_CASE_BODY(no_activation)
 {
-    std::auto_ptr< process::child > child = process::child::fork_capture(
+    std::unique_ptr< process::child > child = process::child::fork_capture(
         child_sleep< 1 >);
 
     datetime::timestamp start = datetime::timestamp::now();

--- a/utils/process/executor.cpp
+++ b/utils/process/executor.cpp
@@ -541,10 +541,10 @@ struct utils::process::executor::executor_handle::impl : utils::noncopyable {
     size_t last_subprocess;
 
     /// Interrupts handler.
-    std::auto_ptr< signals::interrupts_handler > interrupts_handler;
+    std::unique_ptr< signals::interrupts_handler > interrupts_handler;
 
     /// Root work directory for all executed subprocesses.
-    std::auto_ptr< fs::auto_directory > root_work_directory;
+    std::unique_ptr< fs::auto_directory > root_work_directory;
 
     /// Mapping of PIDs to the data required at run time.
     exec_handles_map all_exec_handles;
@@ -809,7 +809,7 @@ executor::executor_handle::spawn_post(
     const fs::path& stderr_file,
     const datetime::delta& timeout,
     const optional< passwd::user > unprivileged_user,
-    std::auto_ptr< process::child > child)
+    std::unique_ptr< process::child > child)
 {
     const exec_handle handle(std::shared_ptr< exec_handle::impl >(
         new exec_handle::impl(
@@ -855,7 +855,7 @@ executor::exec_handle
 executor::executor_handle::spawn_followup_post(
     const exit_handle& base,
     const datetime::delta& timeout,
-    std::auto_ptr< process::child > child)
+    std::unique_ptr< process::child > child)
 {
     INV(*base.state_owners() > 0);
     const exec_handle handle(std::shared_ptr< exec_handle::impl >(

--- a/utils/process/executor.hpp
+++ b/utils/process/executor.hpp
@@ -187,12 +187,12 @@ class executor_handle {
                            const utils::fs::path&,
                            const utils::datetime::delta&,
                            const utils::optional< utils::passwd::user >,
-                           std::auto_ptr< utils::process::child >);
+                           std::unique_ptr< utils::process::child >);
 
     void spawn_followup_pre(void);
     exec_handle spawn_followup_post(const exit_handle&,
                                     const utils::datetime::delta&,
-                                    std::auto_ptr< utils::process::child >);
+                                    std::unique_ptr< utils::process::child >);
 
 public:
     ~executor_handle(void);

--- a/utils/process/executor.ipp
+++ b/utils/process/executor.ipp
@@ -129,7 +129,7 @@ executor::executor_handle::spawn(
     const fs::path stderr_path = stderr_target ?
         stderr_target.get() : (unique_work_directory / detail::stderr_name);
 
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         detail::run_child< Hook >(hook,
                                   unique_work_directory,
                                   unique_work_directory / detail::work_subdir,
@@ -137,7 +137,7 @@ executor::executor_handle::spawn(
         stdout_path, stderr_path);
 
     return spawn_post(unique_work_directory, stdout_path, stderr_path,
-                      timeout, unprivileged_user, child);
+                      timeout, unprivileged_user, std::move(child));
 }
 
 
@@ -165,14 +165,14 @@ executor::executor_handle::spawn_followup(Hook hook,
 {
     spawn_followup_pre();
 
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         detail::run_child< Hook >(hook,
                                   base.control_directory(),
                                   base.work_directory(),
                                   base.unprivileged_user()),
         base.stdout_file(), base.stderr_file());
 
-    return spawn_followup_post(base, timeout, child);
+    return spawn_followup_post(base, timeout, std::move(child));
 }
 
 

--- a/utils/process/fdstream.hpp
+++ b/utils/process/fdstream.hpp
@@ -52,7 +52,7 @@ class ifdstream : public std::istream, noncopyable
     struct impl;
 
     /// Pointer to the shared internal implementation.
-    std::auto_ptr< impl > _pimpl;
+    std::unique_ptr< impl > _pimpl;
 
 public:
     explicit ifdstream(const int);

--- a/utils/process/isolation_test.cpp
+++ b/utils/process/isolation_test.cpp
@@ -78,7 +78,7 @@ template< typename Hook >
 static process::status
 fork_and_run(Hook hook)
 {
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         hook, fs::path("subprocess.stdout"), fs::path("subprocess.stderr"));
     const process::status status = child->wait();
 

--- a/utils/process/operations_test.cpp
+++ b/utils/process/operations_test.cpp
@@ -161,7 +161,7 @@ write_loop(const int fd)
 static void
 check_exec_no_args(const atf::tests::tc* tc, const exec_function do_exec)
 {
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_exec(do_exec, get_helpers(tc), process::args_vector()),
         fs::path("stdout"), fs::path("stderr"));
     const process::status status = child->wait();
@@ -183,7 +183,7 @@ check_exec_some_args(const atf::tests::tc* tc, const exec_function do_exec)
     args.push_back("foo");
     args.push_back("bar");
 
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_exec(do_exec, get_helpers(tc), args),
         fs::path("stdout"), fs::path("stderr"));
     const process::status status = child->wait();
@@ -214,7 +214,7 @@ ATF_TEST_CASE_BODY(exec__fail)
 {
     utils::avoid_coredump_on_crash();
 
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         child_exec(process::exec, fs::path("non-existent"),
                    process::args_vector()),
         fs::path("stdout"), fs::path("stderr"));
@@ -381,7 +381,7 @@ ATF_TEST_CASE_BODY(terminate_self_with__termsig_and_core)
 ATF_TEST_CASE_WITHOUT_HEAD(wait__ok);
 ATF_TEST_CASE_BODY(wait__ok)
 {
-    std::auto_ptr< process::child > child = process::child::fork_capture(
+    std::unique_ptr< process::child > child = process::child::fork_capture(
         child_exit< 15 >);
     const pid_t pid = child->pid();
     child.reset();  // Ensure there is no conflict between destructor and wait.

--- a/utils/process/systembuf.hpp
+++ b/utils/process/systembuf.hpp
@@ -52,7 +52,7 @@ class systembuf : public std::streambuf, noncopyable {
     struct impl;
 
     /// Pointer to the shared internal implementation.
-    std::auto_ptr< impl > _pimpl;
+    std::unique_ptr< impl > _pimpl;
 
 protected:
     int_type underflow(void);

--- a/utils/signals/interrupts.cpp
+++ b/utils/signals/interrupts.cpp
@@ -65,11 +65,11 @@ static pids_set pids_to_kill;
 
 
 /// Programmer status for the SIGHUP signal.
-static std::auto_ptr< signals::programmer > sighup_handler;
+static std::unique_ptr< signals::programmer > sighup_handler;
 /// Programmer status for the SIGINT signal.
-static std::auto_ptr< signals::programmer > sigint_handler;
+static std::unique_ptr< signals::programmer > sigint_handler;
 /// Programmer status for the SIGTERM signal.
-static std::auto_ptr< signals::programmer > sigterm_handler;
+static std::unique_ptr< signals::programmer > sigterm_handler;
 
 
 /// Signal mask to restore after exiting a signal inhibited section.
@@ -127,17 +127,17 @@ setup_handlers(void)
 
     // Create the handlers on the stack first so that, if any of them fails, the
     // stack unwinding cleans things up.
-    std::auto_ptr< signals::programmer > tmp_sighup_handler(
+    std::unique_ptr< signals::programmer > tmp_sighup_handler(
         new signals::programmer(SIGHUP, signal_handler));
-    std::auto_ptr< signals::programmer > tmp_sigint_handler(
+    std::unique_ptr< signals::programmer > tmp_sigint_handler(
         new signals::programmer(SIGINT, signal_handler));
-    std::auto_ptr< signals::programmer > tmp_sigterm_handler(
+    std::unique_ptr< signals::programmer > tmp_sigterm_handler(
         new signals::programmer(SIGTERM, signal_handler));
 
     // Now, update the global pointers, which is an operation that cannot fail.
-    sighup_handler = tmp_sighup_handler;
-    sigint_handler = tmp_sigint_handler;
-    sigterm_handler = tmp_sigterm_handler;
+    sighup_handler = std::move(tmp_sighup_handler);
+    sigint_handler = std::move(tmp_sigint_handler);
+    sigterm_handler = std::move(tmp_sigterm_handler);
 }
 
 

--- a/utils/signals/interrupts_test.cpp
+++ b/utils/signals/interrupts_test.cpp
@@ -202,9 +202,9 @@ ATF_TEST_CASE_HEAD(interrupts_handler__kill_children)
 }
 ATF_TEST_CASE_BODY(interrupts_handler__kill_children)
 {
-    std::auto_ptr< process::child > child1(process::child::fork_files(
+    std::unique_ptr< process::child > child1(process::child::fork_files(
          pause_child, fs::path("/dev/stdout"), fs::path("/dev/stderr")));
-    std::auto_ptr< process::child > child2(process::child::fork_files(
+    std::unique_ptr< process::child > child2(process::child::fork_files(
          pause_child, fs::path("/dev/stdout"), fs::path("/dev/stderr")));
 
     signals::interrupts_handler interrupts;

--- a/utils/signals/misc_test.cpp
+++ b/utils/signals/misc_test.cpp
@@ -99,7 +99,7 @@ run_reset_all(void)
 ATF_TEST_CASE_WITHOUT_HEAD(reset__ok);
 ATF_TEST_CASE_BODY(reset__ok)
 {
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         program_reset_raise, fs::path("/dev/stdout"), fs::path("/dev/stderr"));
     process::status status = child->wait();
     ATF_REQUIRE(status.signaled());
@@ -117,7 +117,7 @@ ATF_TEST_CASE_BODY(reset__invalid)
 ATF_TEST_CASE_WITHOUT_HEAD(reset_all);
 ATF_TEST_CASE_BODY(reset_all)
 {
-    std::auto_ptr< process::child > child = process::child::fork_files(
+    std::unique_ptr< process::child > child = process::child::fork_files(
         run_reset_all, fs::path("/dev/stdout"), fs::path("/dev/stderr"));
     process::status status = child->wait();
     ATF_REQUIRE(status.exited());

--- a/utils/signals/programmer.hpp
+++ b/utils/signals/programmer.hpp
@@ -47,7 +47,7 @@ class programmer : noncopyable {
     struct impl;
 
     /// Pointer to the shared internal implementation.
-    std::auto_ptr< impl > _pimpl;
+    std::unique_ptr< impl > _pimpl;
 
 public:
     programmer(const int, const handler_type);

--- a/utils/signals/timer.cpp
+++ b/utils/signals/timer.cpp
@@ -107,7 +107,7 @@ class global_state : utils::noncopyable {
     ::itimerval _old_timeval;
 
     /// Programmer for the SIGALRM handler.
-    std::auto_ptr< signals::programmer > _sigalrm_programmer;
+    std::unique_ptr< signals::programmer > _sigalrm_programmer;
 
     /// Time of the current activation of the timer.
     datetime::timestamp _timer_activation;
@@ -347,7 +347,7 @@ public:
 
 
 /// Unique instance of the global state.
-static std::auto_ptr< global_state > globals;
+static std::unique_ptr< global_state > globals;
 
 
 /// SIGALRM handler for the timer implementation.

--- a/utils/signals/timer.hpp
+++ b/utils/signals/timer.hpp
@@ -60,7 +60,7 @@ class timer : noncopyable {
     struct impl;
 
     /// Pointer to the shared internal implementation.
-    std::auto_ptr< impl > _pimpl;
+    std::unique_ptr< impl > _pimpl;
 
     friend void detail::invoke_do_fired(timer*);
     void do_fired(void);

--- a/utils/stream.cpp
+++ b/utils/stream.cpp
@@ -59,10 +59,10 @@ static const fs::path stderr_path("/dev/stderr");
 /// \param path The path to the output file to be created.
 ///
 /// \return A pointer to a new output stream.
-std::auto_ptr< std::ostream >
+std::unique_ptr< std::ostream >
 utils::open_ostream(const fs::path& path)
 {
-    std::auto_ptr< std::ostream > out;
+    std::unique_ptr< std::ostream > out;
     if (path == stdout_path) {
         out.reset(new std::ofstream());
         out->copyfmt(std::cout);

--- a/utils/stream.hpp
+++ b/utils/stream.hpp
@@ -46,7 +46,7 @@
 namespace utils {
 
 
-std::auto_ptr< std::ostream > open_ostream(const utils::fs::path&);
+std::unique_ptr< std::ostream > open_ostream(const utils::fs::path&);
 std::size_t stream_length(std::istream&);
 std::string read_file(const utils::fs::path&);
 std::string read_stream(std::istream&);

--- a/utils/stream_test.cpp
+++ b/utils/stream_test.cpp
@@ -43,7 +43,7 @@ ATF_TEST_CASE_BODY(open_ostream__stdout)
 {
     const pid_t pid = atf::utils::fork();
     if (pid == 0) {
-        std::auto_ptr< std::ostream > output = utils::open_ostream(
+        std::unique_ptr< std::ostream > output = utils::open_ostream(
             fs::path("/dev/stdout"));
         (*output) << "Message to stdout\n";
         output.reset();
@@ -58,7 +58,7 @@ ATF_TEST_CASE_BODY(open_ostream__stderr)
 {
     const pid_t pid = atf::utils::fork();
     if (pid == 0) {
-        std::auto_ptr< std::ostream > output = utils::open_ostream(
+        std::unique_ptr< std::ostream > output = utils::open_ostream(
             fs::path("/dev/stderr"));
         (*output) << "Message to stderr\n";
         output.reset();
@@ -73,7 +73,7 @@ ATF_TEST_CASE_BODY(open_ostream__other)
 {
     const pid_t pid = atf::utils::fork();
     if (pid == 0) {
-        std::auto_ptr< std::ostream > output = utils::open_ostream(
+        std::unique_ptr< std::ostream > output = utils::open_ostream(
             fs::path("some-file.txt"));
         (*output) << "Message to other file\n";
         output.reset();


### PR DESCRIPTION
A few places were assigning auto_ptr<>s depending on the ownership handoff.  These now use an explicit std::move() as required by unique_ptr<>.