### PR TITLE
Null cleanups

### DIFF
--- a/utils/fs/directory.cpp
+++ b/utils/fs/directory.cpp
@@ -193,7 +193,7 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
         // minimum C++ standard is C++20.
         result = ::readdir(_dirp);
         if (result == NULL) {
-            _entry.reset(NULL);
+            _entry.reset();
             close();
         } else {
             _entry.reset(new directory_entry(result->d_name));

--- a/utils/logging/operations.cpp
+++ b/utils/logging/operations.cpp
@@ -245,7 +245,7 @@ logging::set_inmemory(void)
     if (globals->logfile.get() != NULL) {
         INV(globals->backlog.empty());
         globals->logfile->flush();
-        globals->logfile.reset(NULL);
+        globals->logfile.reset();
     }
 }
 

--- a/utils/process/child.cpp
+++ b/utils/process/child.cpp
@@ -223,7 +223,7 @@ process::child::fork_capture_aux(void)
             std::cerr << F("Failed to set up subprocess: %s\n") % e.what();
             std::abort();
         }
-        return std::unique_ptr< process::child >(NULL);
+        return {};
     } else {
         ::close(fds[1]);
         LD(F("Spawned process %s: stdout and stderr inherited") % pid);
@@ -284,7 +284,7 @@ process::child::fork_files_aux(const fs::path& stdout_file,
             std::cerr << F("Failed to set up subprocess: %s\n") % e.what();
             std::abort();
         }
-        return std::unique_ptr< process::child >(NULL);
+        return {};
     } else {
         LD(F("Spawned process %s: stdout=%s, stderr=%s") % pid % stdout_file %
            stderr_file);

--- a/utils/process/child.cpp
+++ b/utils/process/child.cpp
@@ -206,12 +206,12 @@ process::child::fork_capture_aux(void)
         new signals::interrupts_inhibiter);
     pid_t pid = detail::syscall_fork();
     if (pid == -1) {
-        inhibiter.reset(NULL);  // Unblock signals.
+        inhibiter.reset();  // Unblock signals.
         ::close(fds[0]);
         ::close(fds[1]);
         throw process::system_error("fork(2) failed", errno);
     } else if (pid == 0) {
-        inhibiter.reset(NULL);  // Unblock signals.
+        inhibiter.reset();  // Unblock signals.
         ::setsid();
 
         try {
@@ -263,10 +263,10 @@ process::child::fork_files_aux(const fs::path& stdout_file,
         new signals::interrupts_inhibiter);
     pid_t pid = detail::syscall_fork();
     if (pid == -1) {
-        inhibiter.reset(NULL);  // Unblock signals.
+        inhibiter.reset();  // Unblock signals.
         throw process::system_error("fork(2) failed", errno);
     } else if (pid == 0) {
-        inhibiter.reset(NULL);  // Unblock signals.
+        inhibiter.reset();  // Unblock signals.
         ::setsid();
 
         try {
@@ -289,7 +289,7 @@ process::child::fork_files_aux(const fs::path& stdout_file,
         LD(F("Spawned process %s: stdout=%s, stderr=%s") % pid % stdout_file %
            stderr_file);
         signals::add_pid_to_kill(pid);
-        inhibiter.reset(NULL);  // Unblock signals.
+        inhibiter.reset();  // Unblock signals.
         return std::unique_ptr< process::child >(
             new process::child(new impl(pid, NULL)));
     }

--- a/utils/process/executor.cpp
+++ b/utils/process/executor.cpp
@@ -633,10 +633,10 @@ struct utils::process::executor::executor_handle::impl : utils::noncopyable {
                 "this could be an internal error or a buggy test") %
                 root_work_directory->directory() % e.what());
         }
-        root_work_directory.reset(NULL);
+        root_work_directory.reset();
 
         interrupts_handler->unprogram();
-        interrupts_handler.reset(NULL);
+        interrupts_handler.reset();
     }
 
     /// Common code to run after any of the wait calls.

--- a/utils/signals/interrupts.cpp
+++ b/utils/signals/interrupts.cpp
@@ -145,9 +145,9 @@ setup_handlers(void)
 static void
 cleanup_handlers(void)
 {
-    sighup_handler->unprogram(); sighup_handler.reset(NULL);
-    sigint_handler->unprogram(); sigint_handler.reset(NULL);
-    sigterm_handler->unprogram(); sigterm_handler.reset(NULL);
+    sighup_handler->unprogram(); sighup_handler.reset();
+    sigint_handler->unprogram(); sigint_handler.reset();
+    sigterm_handler->unprogram(); sigterm_handler.reset();
 }
 
 

--- a/utils/signals/timer.cpp
+++ b/utils/signals/timer.cpp
@@ -257,7 +257,7 @@ public:
             _timer_activation = timer->when();
             add_to_all_timers(timer);
         } catch (...) {
-            _sigalrm_programmer.reset(NULL);
+            _sigalrm_programmer.reset();
             throw;
         }
     }
@@ -276,7 +276,7 @@ public:
         }
 
         _sigalrm_programmer->unprogram();
-        _sigalrm_programmer.reset(NULL);
+        _sigalrm_programmer.reset();
     }
 
     /// Programs a new timer, possibly adjusting the global system timer.
@@ -530,7 +530,7 @@ signals::timer::unprogram(void)
     }
 
     if (!globals->unprogram(this)) {
-        globals.reset(NULL);
+        globals.reset();
     }
     _pimpl->programmed = false;
 


### PR DESCRIPTION
The first commit fixes breakage from my earlier change when building with GCC (which uses __null for NULL) or for clang on non-FreeBSD platforms (which use 0 or __null for NULL).

The second commit is just a cosmetic cleanup.
