### PR TITLE
kyua: Try harder to delete directories.

### DIFF
--- a/utils/fs/operations.cpp
+++ b/utils/fs/operations.cpp
@@ -692,6 +692,7 @@ fs::rm_r(const fs::path& directory)
 {
     const fs::directory dir(directory);
 
+    ::chmod(directory.c_str(), 0700);
     for (fs::directory::const_iterator iter = dir.begin(); iter != dir.end();
          ++iter) {
         if (iter->name == "." || iter->name == "..")
@@ -701,6 +702,7 @@ fs::rm_r(const fs::path& directory)
 
         if (fs::is_directory(entry)) {
             LD(F("Descending into %s") % entry);
+            ::chmod(entry.c_str(), 0700);
             fs::rm_r(entry);
         } else {
             LD(F("Removing file %s") % entry);

--- a/utils/fs/operations_test.cpp
+++ b/utils/fs/operations_test.cpp
@@ -664,6 +664,19 @@ ATF_TEST_CASE_BODY(rm_r__files_and_directories)
 }
 
 
+ATF_TEST_CASE_WITHOUT_HEAD(rm_r__bad_perms);
+ATF_TEST_CASE_BODY(rm_r__bad_perms)
+{
+    fs::mkdir(fs::path("root"), 0755);
+    fs::mkdir(fs::path("root/dir"), 0755);
+    atf::utils::create_file("root/dir/file", "");
+    ::chmod(fs::path("root/dir").c_str(), 0000);
+    ATF_REQUIRE(lookup(".", "root", S_IFDIR));
+    fs::rm_r(fs::path("root"));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
+}
+
+
 ATF_TEST_CASE_WITHOUT_HEAD(rmdir__ok)
 ATF_TEST_CASE_BODY(rmdir__ok)
 {
@@ -811,6 +824,7 @@ ATF_INIT_TEST_CASES(tcs)
 
     ATF_ADD_TEST_CASE(tcs, rm_r__empty);
     ATF_ADD_TEST_CASE(tcs, rm_r__files_and_directories);
+    ATF_ADD_TEST_CASE(tcs, rm_r__bad_perms);
 
     ATF_ADD_TEST_CASE(tcs, rmdir__ok);
     ATF_ADD_TEST_CASE(tcs, rmdir__fail);


### PR DESCRIPTION
When recursing into a directory to delete it, start by chmod'ing it to 0700.  This fixes an issue where kyua is able to run, but not debug, a test case that creates unwriteable directories, because when debugging it tries (and fails) to delete the directory after the test completes.

Sponsored by:   Klara, Inc.
Reviewed by:    igoro
Differential Revision:  https://reviews.freebsd.org/D51229