### PR TITLE
Make "test" command actually report about workdir cleanup issues

### DIFF
--- a/drivers/run_tests.cpp
+++ b/drivers/run_tests.cpp
@@ -209,7 +209,7 @@ finish_test(scheduler::result_handle_ptr result_handle,
     hooks.got_result(
         *test_result_handle->test_program(),
         test_result_handle->test_case_name(),
-        test_result_handle->test_result(),
+        test_result,
         result_handle->end_time() - result_handle->start_time());
 }
 


### PR DESCRIPTION
This is upstreaming of the approved and landed patch: https://reviews.freebsd.org/D51136