### PR TITLE
Make "debug -p" skip writing stdout/stderr to tmp files

### DIFF
--- a/cli/cmd_debug.cpp
+++ b/cli/cmd_debug.cpp
@@ -149,7 +149,11 @@ cmd_debug::run(cmdline::ui* ui, const cmdline::parsed_cmdline& cmdline,
     const engine::test_filter filter = engine::test_filter::parse(
         test_case_name);
 
-    auto debugger = std::shared_ptr< engine::debugger >(new dbg(ui, cmdline));
+    engine::debugger_ptr debugger = nullptr;
+    if (cmdline.has_option(pause_before_cleanup_upon_fail_option.long_name())
+        || cmdline.has_option(pause_before_cleanup_option.long_name())) {
+        debugger = std::shared_ptr< engine::debugger >(new dbg(ui, cmdline));
+    }
 
     const drivers::debug_test::result result = drivers::debug_test::drive(
         debugger,

--- a/engine/scheduler.hpp
+++ b/engine/scheduler.hpp
@@ -74,6 +74,8 @@
 #include "utils/process/executor_fwd.hpp"
 #include "utils/process/status_fwd.hpp"
 
+using utils::none;
+
 namespace engine {
 namespace scheduler {
 
@@ -248,7 +250,9 @@ public:
                                      const utils::config::tree&);
     exec_handle spawn_test(const model::test_program_ptr,
                            const std::string&,
-                           const utils::config::tree&);
+                           const utils::config::tree&,
+                           const utils::optional<utils::fs::path>& = none,
+                           const utils::optional<utils::fs::path>& = none);
     result_handle_ptr wait_any(void);
 
     result_handle_ptr debug_test(const model::test_program_ptr,


### PR DESCRIPTION
It reflects already landed change: https://reviews.freebsd.org/D54363