### PR TITLE
utils/process/child_test: fix returned type

### DIFF
--- a/utils/process/child_test.cpp
+++ b/utils/process/child_test.cpp
@@ -255,7 +255,7 @@ open_fail(const char* path, const int flags, ...) throw()
 ///
 /// \return Always -1.
 template< int Errno >
-static pid_t
+static int
 pipe_fail(int* /* fildes */) throw()
 {
     errno = Errno;


### PR DESCRIPTION
The returned type for `pipe(2)` should be `int`, not `pid_t`.

Closes:	#174