### PR TITLE
kyua manuals: Correct --results-file short form

### DIFF
--- a/doc/kyua-db-exec.1.in
+++ b/doc/kyua-db-exec.1.in
@@ -62,7 +62,7 @@ The following subcommand options are recognized:
 .Bl -tag -width XX
 .It Fl -no-headers
 Avoids printing the headers of the table in the output of the command.
-.It Fl -results-file Ar path , Fl s Ar path
+.It Fl -results-file Ar path , Fl r Ar path
 __include__ results-file-flag-read.mdoc
 .El
 .Ss Results files

--- a/doc/kyua-db-migrate.1.in
+++ b/doc/kyua-db-migrate.1.in
@@ -47,7 +47,7 @@ database lives.
 .Pp
 The following subcommand options are recognized:
 .Bl -tag -width XX
-.It Fl -results-file Ar path , Fl s Ar path
+.It Fl -results-file Ar path , Fl r Ar path
 __include__ results-file-flag-read.mdoc
 .El
 .Ss Results files

--- a/doc/kyua-report-html.1.in
+++ b/doc/kyua-report-html.1.in
@@ -64,7 +64,7 @@ The directory must not exist unless the
 option is provided.
 The default is
 .Pa ./html .
-.It Fl -results-file Ar path , Fl s Ar path
+.It Fl -results-file Ar path , Fl r Ar path
 __include__ results-file-flag-read.mdoc
 .It Fl -results-filter Ar types
 Comma-separated list of the test result types to include in the report.

--- a/doc/kyua-report-junit.1.in
+++ b/doc/kyua-report-junit.1.in
@@ -50,7 +50,7 @@ The following subcommand options are recognized:
 .Bl -tag -width XX
 .It Fl -output Ar directory
 Specifies the file into which to store the JUnit report.
-.It Fl -results-file Ar path , Fl s Ar path
+.It Fl -results-file Ar path , Fl r Ar path
 __include__ results-file-flag-read.mdoc
 .El
 .Ss Caveats

--- a/doc/kyua-report.1.in
+++ b/doc/kyua-report.1.in
@@ -70,7 +70,7 @@ and
 .Pa /dev/stderr
 can be used to specify the standard output and the standard error,
 respectively.
-.It Fl -results-file Ar path , Fl s Ar path
+.It Fl -results-file Ar path , Fl r Ar path
 __include__ results-file-flag-read.mdoc
 .It Fl -results-filter Ar types
 Comma-separated list of the test result types to include in the report.

--- a/doc/kyua-test.1.in
+++ b/doc/kyua-test.1.in
@@ -69,7 +69,7 @@ Specifies the Kyuafile to process.
 Defaults to a
 .Pa Kyuafile
 file in the current directory.
-.It Fl -results-file Ar path , Fl s Ar path
+.It Fl -results-file Ar path , Fl r Ar path
 __include__ results-file-flag-write.mdoc
 .El
 .Pp


### PR DESCRIPTION
kyua's `--results-file` flag maps to `-r`, not `-s`.

Closes:	#267
Obtained from:	FreeBSD/src (bbaa7d628175ee484e31a054fb3cf7b7866cad13)