### PR TITLE
add timeout scaling with new metadata 'timeout_scale'

### DIFF
--- a/doc/kyuafile.5.in
+++ b/doc/kyuafile.5.in
@@ -334,10 +334,20 @@ the test must run as root.
 ATF:
 .Va require.user
 .It Va timeout
-Amount of seconds that the test is allowed to execute before being killed.
+Number of seconds that the test is allowed to execute before being killed.
 .Pp
 ATF:
 .Va timeout
+.It Va timeout_scale
+Positive integer scaling factor applied to
+.Va timeout
+to account for differences in
+performance characteristics between testing environments. For example, this can be
+used to describe slower test execution on emulated architectures using QEMU.
+Defaults (normalized) to the value 1.
+.Pp
+ATF:
+.Va timeout.scale
 .El
 .Ss Recursion
 To reference test programs in another subdirectory, a different

--- a/drivers/report_junit_test.cpp
+++ b/drivers/report_junit_test.cpp
@@ -74,7 +74,8 @@ static const char* const default_metadata =
     "required_memory = 0\n"
     "required_programs is empty\n"
     "required_user is empty\n"
-    "timeout = 300\n";
+    "timeout = 300\n"
+    "timeout_scale = 1\n";
 
 
 /// Formatted metadata for a test case constructed with the "with_metadata" flag
@@ -94,7 +95,8 @@ static const char* const overriden_metadata =
     "required_memory = 0\n"
     "required_programs is empty\n"
     "required_user is empty\n"
-    "timeout = 5678\n";
+    "timeout = 5678\n"
+    "timeout_scale = 1\n";
 
 
 /// Populates the context of the given database.
@@ -216,6 +218,7 @@ ATF_TEST_CASE_BODY(junit_metadata__overrides)
         .add_required_program(fs::path("prog1"))
         .set_required_user("root")
         .set_timeout(datetime::delta(10, 0))
+        .set_timeout_scale(5)
         .build();
 
     const std::string expected = std::string()
@@ -234,7 +237,8 @@ ATF_TEST_CASE_BODY(junit_metadata__overrides)
         + "required_memory = 123\n"
         + "required_programs = prog1\n"
         + "required_user = root\n"
-        + "timeout = 10\n";
+        + "timeout = 10\n"
+        + "timeout_scale = 5\n";
 
     ATF_REQUIRE_EQ(expected, drivers::junit_metadata(metadata));
 }

--- a/engine/atf_list.cpp
+++ b/engine/atf_list.cpp
@@ -145,6 +145,8 @@ engine::parse_atf_metadata(const model::properties_map& props)
                 mdbuilder.set_string("required_user", value);
             } else if (name == "timeout") {
                 mdbuilder.set_string("timeout", value);
+            } else if (name == "timeout.scale") {
+                mdbuilder.set_string("timeout_scale", value);
             } else if (name.length() > 2 && name.substr(0, 2) == "X-") {
                 mdbuilder.add_custom(name.substr(2), value);
             } else {

--- a/engine/atf_list_test.cpp
+++ b/engine/atf_list_test.cpp
@@ -74,6 +74,7 @@ ATF_TEST_CASE_BODY(parse_atf_metadata__override_all)
     properties["require.progs"] = "/bin/ls svn";
     properties["require.user"] = "root";
     properties["timeout"] = "123";
+    properties["timeout.scale"] = "456";
     properties["X-foo"] = "value1";
     properties["X-bar"] = "value2";
     properties["X-baz-www"] = "value3";
@@ -100,6 +101,7 @@ ATF_TEST_CASE_BODY(parse_atf_metadata__override_all)
         .set_required_memory(units::bytes::parse("1m"))
         .set_required_user("root")
         .set_timeout(datetime::delta(123, 0))
+        .set_timeout_scale(456)
         .build();
     ATF_REQUIRE_EQ(exp_md, md);
 }

--- a/engine/scheduler.cpp
+++ b/engine/scheduler.cpp
@@ -1306,7 +1306,7 @@ scheduler::scheduler_handle::spawn_test(
     const executor::exec_handle handle = _pimpl->generic.spawn(
         run_test_program(interface, test_program, test_case_name,
                          user_config),
-        test_case.get_metadata().timeout(),
+        test_case.get_metadata().timeout() * test_case.get_metadata().timeout_scale(),
         unprivileged_user, stdout_target, stderr_target);
 
     const exec_data_ptr data(new test_exec_data(

--- a/integration/cmd_report_junit_test.sh
+++ b/integration/cmd_report_junit_test.sh
@@ -109,6 +109,7 @@ required_memory = 0
 required_programs is empty
 required_user is empty
 timeout = 300
+timeout_scale = 1
 
 Timing information
 ------------------
@@ -150,6 +151,7 @@ required_memory = 0
 required_programs is empty
 required_user is empty
 timeout = 300
+timeout_scale = 1
 
 Timing information
 ------------------
@@ -229,6 +231,7 @@ required_memory = 0
 required_programs is empty
 required_user is empty
 timeout = 300
+timeout_scale = 1
 
 Timing information
 ------------------
@@ -270,6 +273,7 @@ required_memory = 0
 required_programs is empty
 required_user is empty
 timeout = 300
+timeout_scale = 1
 
 Timing information
 ------------------

--- a/integration/cmd_report_test.sh
+++ b/integration/cmd_report_test.sh
@@ -263,6 +263,7 @@ Metadata:
     required_programs is empty
     required_user is empty
     timeout = 300
+    timeout_scale = 1
 
 Standard output:
 This is the stdout of skip

--- a/model/metadata.cpp
+++ b/model/metadata.cpp
@@ -260,6 +260,7 @@ init_tree(config::tree& tree)
     tree.define< paths_set_node >("required_programs");
     tree.define< user_node >("required_user");
     tree.define< delta_node >("timeout");
+    tree.define< config::positive_int_node >("timeout_scale");
 }
 
 
@@ -286,9 +287,8 @@ set_defaults(config::tree& tree)
     tree.set< config::strings_set_node >("required_kmods", model::strings_set());
     tree.set< paths_set_node >("required_programs", model::paths_set());
     tree.set< user_node >("required_user", "");
-    // TODO(jmmv): We shouldn't be setting a default timeout like this.  See
-    // Issue 5 for details.
     tree.set< delta_node >("timeout", datetime::delta(300, 0));
+    tree.set< config::positive_int_node >("timeout_scale", 1);
 }
 
 
@@ -654,6 +654,19 @@ model::metadata::timeout(void) const
         return _pimpl->props.lookup< delta_node >("timeout");
     } else {
         return get_defaults().lookup< delta_node >("timeout");
+    }
+}
+
+/// Returns the timeout scale factor of the test.
+///
+/// \return A positive scale factor
+size_t
+model::metadata::timeout_scale(void) const
+{
+    if (_pimpl->props.is_set("timeout_scale")) {
+        return _pimpl->props.lookup< config::positive_int_node >("timeout_scale");
+    } else {
+        return get_defaults().lookup< config::positive_int_node >("timeout_scale");
     }
 }
 
@@ -1139,6 +1152,20 @@ model::metadata_builder&
 model::metadata_builder::set_timeout(const datetime::delta& timeout)
 {
     set< delta_node >(_pimpl->props, "timeout", timeout);
+    return *this;
+}
+
+/// Sets the timeout scale factor of the test.
+///
+/// \param timeout The timeout scale factor to set.
+///
+/// \return A reference to this builder.
+///
+/// \throw model::error If the value is invalid.
+model::metadata_builder&
+model::metadata_builder::set_timeout_scale(const size_t scale)
+{
+    set< config::positive_int_node >(_pimpl->props, "timeout_scale", scale);
     return *this;
 }
 

--- a/model/metadata.hpp
+++ b/model/metadata.hpp
@@ -80,6 +80,7 @@ public:
     const paths_set& required_programs(void) const;
     const std::string& required_user(void) const;
     const utils::datetime::delta& timeout(void) const;
+    size_t timeout_scale(void) const;
 
     model::properties_map to_properties(void) const;
 
@@ -127,6 +128,7 @@ public:
     metadata_builder& set_required_user(const std::string&);
     metadata_builder& set_string(const std::string&, const std::string&);
     metadata_builder& set_timeout(const utils::datetime::delta&);
+    metadata_builder& set_timeout_scale(const size_t);
 
     metadata build(void) const;
 };

--- a/model/metadata_test.cpp
+++ b/model/metadata_test.cpp
@@ -62,6 +62,7 @@ ATF_TEST_CASE_BODY(defaults)
     ATF_REQUIRE(md.required_programs().empty());
     ATF_REQUIRE(md.required_user().empty());
     ATF_REQUIRE(datetime::delta(300, 0) == md.timeout());
+    ATF_REQUIRE(1 == md.timeout_scale());
 }
 
 
@@ -199,6 +200,7 @@ ATF_TEST_CASE_BODY(override_all_with_setters)
     const std::string user = "root";
 
     const datetime::delta timeout(123, 0);
+    const size_t timeout_scale = 456;
 
     const model::metadata md = model::metadata_builder()
         .set_allowed_architectures(architectures)
@@ -214,6 +216,7 @@ ATF_TEST_CASE_BODY(override_all_with_setters)
         .set_required_programs(programs)
         .set_required_user(user)
         .set_timeout(timeout)
+        .set_timeout_scale(timeout_scale)
         .build();
 
     ATF_REQUIRE(architectures == md.allowed_architectures());
@@ -229,6 +232,7 @@ ATF_TEST_CASE_BODY(override_all_with_setters)
     ATF_REQUIRE(programs == md.required_programs());
     ATF_REQUIRE_EQ(user, md.required_user());
     ATF_REQUIRE(timeout == md.timeout());
+    ATF_REQUIRE(timeout_scale == md.timeout_scale());
 }
 
 
@@ -267,6 +271,7 @@ ATF_TEST_CASE_BODY(override_all_with_set_string)
     const std::string user = "unprivileged";
 
     const datetime::delta timeout(45, 0);
+    const size_t timeout_scale = 90;
 
     const model::metadata md = model::metadata_builder()
         .set_string("allowed_architectures", "a1 a2")
@@ -282,6 +287,7 @@ ATF_TEST_CASE_BODY(override_all_with_set_string)
         .set_string("required_programs", "program /absolute/prog")
         .set_string("required_user", "unprivileged")
         .set_string("timeout", "45")
+        .set_string("timeout_scale", "90")
         .build();
 
     ATF_REQUIRE(architectures == md.allowed_architectures());
@@ -297,6 +303,7 @@ ATF_TEST_CASE_BODY(override_all_with_set_string)
     ATF_REQUIRE(programs == md.required_programs());
     ATF_REQUIRE_EQ(user, md.required_user());
     ATF_REQUIRE(timeout == md.timeout());
+    ATF_REQUIRE(timeout_scale == md.timeout_scale());
 }
 
 
@@ -328,6 +335,7 @@ ATF_TEST_CASE_BODY(to_properties)
     props["required_programs"] = "";
     props["required_user"] = "";
     props["timeout"] = "300";
+    props["timeout_scale"] = "1";
     ATF_REQUIRE_EQ(props, md.to_properties());
 }
 
@@ -415,7 +423,8 @@ ATF_TEST_CASE_BODY(output__defaults)
                    "required_configs='', "
                    "required_disk_space='0', required_files='', "
                    "required_kmods='', required_memory='0', "
-                   "required_programs='', required_user='', timeout='300'}",
+                   "required_programs='', required_user='', "
+                   "timeout='300', timeout_scale='1'}",
                    str.str());
 }
 
@@ -438,7 +447,8 @@ ATF_TEST_CASE_BODY(output__some_values)
         "required_configs='', "
         "required_disk_space='0', required_files='bar foo', "
         "required_kmods='', required_memory='1.00K', "
-        "required_programs='', required_user='', timeout='300'}",
+        "required_programs='', required_user='', "
+        "timeout='300', timeout_scale='1'}",
         str.str());
 }
 

--- a/model/test_case_test.cpp
+++ b/model/test_case_test.cpp
@@ -205,7 +205,8 @@ ATF_TEST_CASE_BODY(test_case__output)
         "is_exclusive='false', "
         "required_configs='', required_disk_space='0', required_files='', "
         "required_kmods='', required_memory='0', "
-        "required_programs='', required_user='', timeout='300'}}",
+        "required_programs='', required_user='', "
+        "timeout='300', timeout_scale='1'}}",
         str.str());
 }
 

--- a/model/test_program_test.cpp
+++ b/model/test_program_test.cpp
@@ -548,7 +548,8 @@ check_output__no_test_cases(void)
         "has_cleanup='false', is_exclusive='false', "
         "required_configs='', required_disk_space='0', required_files='', "
         "required_kmods='', required_memory='0', "
-        "required_programs='', required_user='', timeout='300'}, "
+        "required_programs='', required_user='', "
+        "timeout='300', timeout_scale='1'}, "
         "test_cases=map()}",
         str.str());
 }
@@ -598,7 +599,8 @@ check_output__some_test_cases(void)
         "has_cleanup='false', is_exclusive='false', "
         "required_configs='', required_disk_space='0', required_files='', "
         "required_kmods='', required_memory='0', "
-        "required_programs='', required_user='', timeout='300'}, "
+        "required_programs='', required_user='', "
+        "timeout='300', timeout_scale='1'}, "
         "test_cases=map("
         "another-name=test_case{name='another-name', "
         "metadata=metadata{allowed_architectures='a', allowed_platforms='', "
@@ -606,14 +608,16 @@ check_output__some_test_cases(void)
         "has_cleanup='false', is_exclusive='false', "
         "required_configs='', required_disk_space='0', required_files='', "
         "required_kmods='', required_memory='0', "
-        "required_programs='', required_user='', timeout='300'}}, "
+        "required_programs='', required_user='', "
+        "timeout='300', timeout_scale='1'}}, "
         "the-name=test_case{name='the-name', "
         "metadata=metadata{allowed_architectures='a', allowed_platforms='foo', "
         "custom.bar='baz', description='', execenv='', execenv_jail_params='', "
         "has_cleanup='false', is_exclusive='false', "
         "required_configs='', required_disk_space='0', required_files='', "
         "required_kmods='', required_memory='0', "
-        "required_programs='', required_user='', timeout='300'}})}",
+        "required_programs='', required_user='', "
+        "timeout='300', timeout_scale='1'}})}",
         str.str());
 }
 


### PR DESCRIPTION
As noted in the manpage, this can be used to account for differences in performance characteristics between execution environments at a global level.

For example, if tests on average take < 5 minutes (current default timeout of 300s) on native x86_64, but take < 20 mins on QEMU-emulated aarch64, `timeout_scale = 4` can be set in `kyua.conf` on the emulated platform only. This can also be narrowly set on a per-test-suite basis to account for a group of exceedingly-long test cases.