### PR TITLE
Add FreeBSD CI using GitHub Actions

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,57 @@
+# Build Kyua on FreeBSD, its primary target platform.
+#
+# FreeBSD is not offered by the GitHub-hosted runners, so this boots a FreeBSD
+# VM under QEMU/KVM on a normal ubuntu-latest runner.
+
+name: FreeBSD
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  freebsd:
+    name: FreeBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build
+        uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d # v1.5.2
+        with:
+          usesh: true
+          cache-after-prepare: true
+          prepare: |
+            pkg install -y autoconf automake libtool atf lutok pkgconf sqlite3
+          run: |
+            set -e
+
+            echo "===== toolchain ====="
+            cc --version | head -2
+            autoconf --version | head -1
+            automake --version | head -1
+
+            echo "===== regenerate build system ====="
+            # ATF installs its m4 macros under /usr/local/share/aclocal, which
+            # is not autoconf's prefix on FreeBSD; see INSTALL.md.
+            autoreconf -i -s -I /usr/local/share/aclocal
+
+            echo "===== configure ====="
+            ./configure --enable-atf
+
+            echo "===== build ====="
+            make
+
+            echo "===== built binary ====="
+            ls -l ./kyua
+            ./kyua about version


### PR DESCRIPTION
Closes #276

Cirrus CI shut down on 2026-06-01, leaving the primary target platform
without CI. This adds a FreeBSD job using `vmactions/freebsd-vm`, which is
what you suggested in #276 -- it boots FreeBSD under QEMU/KVM on a regular
`ubuntu-latest` runner.

Two notes on why this does not simply port `.cirrus.yml` over:

- It does not call `admin/travis-build.sh`. That script runs
  `sudo sysctl -w kernel.core_pattern=core.%p` under `set -e`, and
  `kernel.core_pattern` is a Linux-only sysctl, so the script cannot complete
  on FreeBSD. (This matches what was said in #254 about the config having
  grown stale.)
- The package list adds `libtool`, which `.cirrus.yml` omits even though
  `configure.ac` calls `LT_INIT`.

## Verification

https://github.com/neilpang/kyua/actions/runs/30707623116

```
FreeBSD clang version 19.1.7, Target: x86_64-unknown-freebsd15.1
autoconf (GNU Autoconf) 2.73 / automake (GNU automake) 1.18.1
checking for atf-c++ >= 0.22... yes
checking for atf-sh >= 0.22... /usr/local/bin/atf-sh
lutok 0.6.2, sqlite3 3.53.3, lua 5.4
224 libtool compile / 135 libtool link invocations, all under -Werror
-rwxr-xr-x  1 root 1001 20960904 Aug  1 16:19 ./kyua
kyua (Kyua) 0.14.1
```

Total job time is about 12 minutes; with `cache-after-prepare` enabled the
package install is skipped on subsequent runs.

Currently this only builds. Running the test suite needs kyua itself to
drive the tests, which is a larger question -- happy to follow up with that
separately if you want it.
