### PR TITLE
engine: include `debugger.hpp` in sources

### DIFF
--- a/engine/Makefile.am.inc
+++ b/engine/Makefile.am.inc
@@ -41,6 +41,7 @@ libengine_la_SOURCES += engine/atf_result_fwd.hpp
 libengine_la_SOURCES += engine/config.cpp
 libengine_la_SOURCES += engine/config.hpp
 libengine_la_SOURCES += engine/config_fwd.hpp
+libengine_la_SOURCES += engine/debugger.hpp
 libengine_la_SOURCES += engine/exceptions.cpp
 libengine_la_SOURCES += engine/exceptions.hpp
 libengine_la_SOURCES += engine/filters.cpp


### PR DESCRIPTION
Make sure the library build process accounts for the header; this will ensure that `make distcheck` always succeeds by accounting for all required sources.