### PR TITLE
utils/process/executor_pid_test: disable

### DIFF
--- a/utils/process/.gitignore
+++ b/utils/process/.gitignore
@@ -1,2 +1,1 @@
 helpers
-Kyuafile

--- a/utils/process/Kyuafile
+++ b/utils/process/Kyuafile
@@ -1,0 +1,13 @@
+syntax(2)
+
+test_suite("kyua")
+
+atf_test_program{name="child_test"}
+atf_test_program{name="deadline_killer_test"}
+atf_test_program{name="exceptions_test"}
+atf_test_program{name="executor_test"}
+atf_test_program{name="fdstream_test"}
+atf_test_program{name="isolation_test"}
+atf_test_program{name="operations_test"}
+atf_test_program{name="status_test"}
+atf_test_program{name="systembuf_test"}

--- a/utils/process/Makefile.am.inc
+++ b/utils/process/Makefile.am.inc
@@ -60,16 +60,7 @@ if WITH_ATF
 tests_utils_processdir = $(pkgtestsdir)/utils/process
 
 tests_utils_process_DATA = utils/process/Kyuafile
-EXTRA_DIST += $(tests_utils_process_DATA) utils/process/Kyuafile.in
-
-CLEANFILES+=	utils/process/Kyuafile
-utils/process/Kyuafile: $(top_srcdir)/utils/process/Kyuafile.in
-	cp -f $(top_srcdir)/utils/process/Kyuafile.in utils/process/Kyuafile.tmp
-if FreeBSD
-	printf 'atf_test_program{name="executor_pid_test", required_user="root"}\n' >> \
-	    utils/process/Kyuafile.tmp
-endif
-	mv utils/process/Kyuafile.tmp utils/process/Kyuafile
+EXTRA_DIST += $(tests_utils_process_DATA)
 
 tests_utils_process_PROGRAMS = utils/process/child_test
 utils_process_child_test_SOURCES = utils/process/child_test.cpp
@@ -91,14 +82,6 @@ tests_utils_process_PROGRAMS += utils/process/executor_test
 utils_process_executor_test_SOURCES = utils/process/executor_test.cpp
 utils_process_executor_test_CXXFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
 utils_process_executor_test_LDADD = $(UTILS_LIBS) $(ATF_CXX_LIBS)
-
-# XXX: this test technically works with all BSDs and MacOS.
-if FreeBSD
-tests_utils_process_PROGRAMS += utils/process/executor_pid_test
-utils_process_executor_pid_test_SOURCES = utils/process/executor_pid_test.c
-utils_process_executor_pid_test_CFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
-utils_process_executor_pid_test_LDADD = $(UTILS_LIBS) $(ATF_CXX_LIBS)
-endif
 
 tests_utils_process_PROGRAMS += utils/process/fdstream_test
 utils_process_fdstream_test_SOURCES = utils/process/fdstream_test.cpp


### PR DESCRIPTION
This testcase does not function after the changes introduced in 346f1cec2.

Disable the testcase by removing it to ensure that the test isn't accidentally (re-)enabled when kyua is updated post-0.15.0 in FreeBSD as FreeBSD does not use the build process implemented by this project (for better or for worse).

Fixes:	#293