### PR TITLE
Fix the build for multiple `utils/test_utils.hpp`-dependent test programs

### DIFF
--- a/bootstrap/Makefile.am.inc
+++ b/bootstrap/Makefile.am.inc
@@ -52,7 +52,8 @@ bootstrap_atf_helpers_LDADD = $(ATF_CXX_LIBS)
 
 tests_bootstrap_PROGRAMS += bootstrap/plain_helpers
 bootstrap_plain_helpers_SOURCES = bootstrap/plain_helpers.cpp
-bootstrap_plain_helpers_CXXFLAGS = $(UTILS_CFLAGS)
+bootstrap_plain_helpers_CXXFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
+bootstrap_plain_helpers_LDADD = $(UTILS_CFLAGS) $(ATF_CXX_LDADD)
 
 tests_bootstrap_SCRIPTS = bootstrap/testsuite
 @target_srcdir@bootstrap/package.m4: $(top_srcdir)/configure.ac

--- a/engine/Makefile.am.inc
+++ b/engine/Makefile.am.inc
@@ -116,8 +116,8 @@ engine_filters_test_LDADD = $(ENGINE_LIBS) $(ATF_CXX_LIBS)
 
 tests_engine_PROGRAMS += engine/googletest_helpers
 engine_googletest_helpers_SOURCES = engine/googletest_helpers.cpp
-engine_googletest_helpers_CXXFLAGS = $(UTILS_CFLAGS)
-engine_googletest_helpers_LDADD = $(UTILS_LIBS)
+engine_googletest_helpers_CXXFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
+engine_googletest_helpers_LDADD = $(UTILS_LIBS) $(ATF_CXX_LIBS)
 
 tests_engine_PROGRAMS += engine/googletest_test
 engine_googletest_test_SOURCES = engine/googletest_test.cpp
@@ -141,8 +141,8 @@ engine_kyuafile_test_LDADD = $(ENGINE_LIBS) $(ATF_CXX_LIBS)
 
 tests_engine_PROGRAMS += engine/plain_helpers
 engine_plain_helpers_SOURCES = engine/plain_helpers.cpp
-engine_plain_helpers_CXXFLAGS = $(UTILS_CFLAGS)
-engine_plain_helpers_LDADD = $(UTILS_LIBS)
+engine_plain_helpers_CXXFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
+engine_plain_helpers_LDADD = $(UTILS_LIBS) $(ATF_CXX_LIBS)
 
 tests_engine_PROGRAMS += engine/plain_test
 engine_plain_test_SOURCES = engine/plain_test.cpp
@@ -163,8 +163,8 @@ engine_scanner_test_LDADD = $(ENGINE_LIBS) $(ATF_CXX_LIBS)
 
 tests_engine_PROGRAMS += engine/tap_helpers
 engine_tap_helpers_SOURCES = engine/tap_helpers.cpp
-engine_tap_helpers_CXXFLAGS = $(UTILS_CFLAGS)
-engine_tap_helpers_LDADD = $(UTILS_LIBS)
+engine_tap_helpers_CXXFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
+engine_tap_helpers_LDADD = $(UTILS_LIBS) $(ATF_CXX_LIBS)
 
 tests_engine_PROGRAMS += engine/tap_test
 engine_tap_test_SOURCES = engine/tap_test.cpp


### PR DESCRIPTION
624992b modified `utils/test_utils.hpp` to rely on libatf-c++, but failed to add the dependency to multiple test programs. Add the dependency references to unbreak the build with the affected applications.

Closes: #295