### PR TITLE
Reduce overall lutok dependency

### DIFF
--- a/engine/kyuafile.hpp
+++ b/engine/kyuafile.hpp
@@ -34,11 +34,6 @@
 
 #include "engine/kyuafile_fwd.hpp"
 
-#include <string>
-#include <vector>
-
-#include <lutok/state.hpp>
-
 #include "engine/scheduler_fwd.hpp"
 #include "model/test_program_fwd.hpp"
 #include "utils/config/tree_fwd.hpp"

--- a/engine/kyuafile_test.cpp
+++ b/engine/kyuafile_test.cpp
@@ -27,19 +27,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "engine/kyuafile.hpp"
-
+#include <memory>
 extern "C" {
 #include <unistd.h>
 }
-
-#include <stdexcept>
-#include <typeinfo>
-
 #include <atf-c++.hpp>
-#include <lutok/operations.hpp>
-#include <lutok/state.ipp>
-#include <lutok/test_utils.hpp>
-
 #include "engine/atf.hpp"
 #include "engine/exceptions.hpp"
 #include "engine/plain.hpp"

--- a/utils/Makefile.am.inc
+++ b/utils/Makefile.am.inc
@@ -29,6 +29,14 @@
 UTILS_CFLAGS =
 UTILS_LIBS = libutils.la
 
+# Multiple subdirectories require lutok to build. Just do this once for this
+# component instead of spamming in each of the subdirs' Makefile.am's to reduce
+# overall build noise.
+#
+# TODO(ngie): this should be fixed when moving to an alternative build system.
+UTILS_CFLAGS += $(LUTOK_CFLAGS)
+UTILS_LIBS += $(LUTOK_LIBS)
+
 noinst_LTLIBRARIES += libutils.la
 libutils_la_CPPFLAGS = -DGDB=\"$(GDB)\"
 libutils_la_SOURCES  = utils/auto_array.hpp
@@ -58,6 +66,7 @@ libutils_la_SOURCES += utils/stream.hpp
 libutils_la_SOURCES += utils/units.cpp
 libutils_la_SOURCES += utils/units.hpp
 libutils_la_SOURCES += utils/units_fwd.hpp
+libutils_la_LIBADD =
 nodist_libutils_la_SOURCES = utils/defs.hpp
 
 EXTRA_DIST += utils/test_utils.ipp

--- a/utils/config/Makefile.am.inc
+++ b/utils/config/Makefile.am.inc
@@ -26,9 +26,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-UTILS_CFLAGS += $(LUTOK_CFLAGS)
-UTILS_LIBS += $(LUTOK_LIBS)
-
 libutils_la_CPPFLAGS += $(LUTOK_CFLAGS)
 libutils_la_SOURCES += utils/config/exceptions.cpp
 libutils_la_SOURCES += utils/config/exceptions.hpp
@@ -48,6 +45,7 @@ libutils_la_SOURCES += utils/config/tree.cpp
 libutils_la_SOURCES += utils/config/tree.hpp
 libutils_la_SOURCES += utils/config/tree.ipp
 libutils_la_SOURCES += utils/config/tree_fwd.hpp
+libutils_la_LIBADD += $(LUTOK_LIBS)
 
 if WITH_ATF
 tests_utils_configdir = $(pkgtestsdir)/utils/config

--- a/utils/fs/Makefile.am.inc
+++ b/utils/fs/Makefile.am.inc
@@ -26,9 +26,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-UTILS_CFLAGS += $(LUTOK_CFLAGS)
-UTILS_LIBS += $(LUTOK_LIBS)
-
 libutils_la_CPPFLAGS += $(LUTOK_CFLAGS)
 libutils_la_SOURCES += utils/fs/auto_cleaners.cpp
 libutils_la_SOURCES += utils/fs/auto_cleaners.hpp
@@ -45,6 +42,7 @@ libutils_la_SOURCES += utils/fs/operations.hpp
 libutils_la_SOURCES += utils/fs/path.cpp
 libutils_la_SOURCES += utils/fs/path.hpp
 libutils_la_SOURCES += utils/fs/path_fwd.hpp
+libutils_la_LIBADD += $(LUTOK_LIBS)
 
 if WITH_ATF
 tests_utils_fsdir = $(pkgtestsdir)/utils/fs
@@ -69,8 +67,8 @@ utils_fs_exceptions_test_LDADD = $(UTILS_LIBS) $(ATF_CXX_LIBS)
 
 tests_utils_fs_PROGRAMS += utils/fs/lua_module_test
 utils_fs_lua_module_test_SOURCES = utils/fs/lua_module_test.cpp
-utils_fs_lua_module_test_CXXFLAGS = $(UTILS_CFLAGS) $(ATF_CXX_CFLAGS)
-utils_fs_lua_module_test_LDADD = $(UTILS_LIBS) $(ATF_CXX_LIBS)
+utils_fs_lua_module_test_CXXFLAGS = $(UTILS_CFLAGS) $(LUTOK_CFLAGS) $(ATF_CXX_CFLAGS)
+utils_fs_lua_module_test_LDADD = $(UTILS_LIBS) $(LUTOK_LIBS) $(ATF_CXX_LIBS)
 
 tests_utils_fs_PROGRAMS += utils/fs/operations_test
 utils_fs_operations_test_SOURCES = utils/fs/operations_test.cpp

--- a/utils/logging/Makefile.am.inc
+++ b/utils/logging/Makefile.am.inc
@@ -26,10 +26,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-UTILS_CFLAGS += $(LUTOK_CFLAGS)
-UTILS_LIBS += $(LUTOK_LIBS)
-
-libutils_la_CPPFLAGS += $(LUTOK_CFLAGS)
 libutils_la_SOURCES += utils/logging/macros.hpp
 libutils_la_SOURCES += utils/logging/operations.cpp
 libutils_la_SOURCES += utils/logging/operations.hpp

--- a/utils/text/operations.ipp
+++ b/utils/text/operations.ipp
@@ -31,6 +31,7 @@
 
 #include "utils/text/operations.hpp"
 
+#include <string>
 #include <sstream>
 
 #include "utils/text/exceptions.hpp"


### PR DESCRIPTION
This change reduces the overall lutok dependency in the following ways:
- Reducing duplicate CFLAGS appending.
- Remove unnecessary includes/linkage from headers.

This doesn't reduce the overall dependency on lutok quite yet, but future revisions will decrease the lutok dependency across the source base further by performing additional refactoring.