### PR TITLE
Implement utils::config::positive_int_node::deep_copy

### DIFF
--- a/utils/config/nodes.cpp
+++ b/utils/config/nodes.cpp
@@ -153,7 +153,7 @@ config::detail::inner_node::combine_into(const tree_key& key,
     } catch (const std::bad_cast& unused_e) {
         throw config::bad_combination_error(
             key, "'%s' is an inner node in the base tree but a leaf node in "
-            "the overrides treee");
+            "the overrides tree");
     }
 }
 
@@ -227,8 +227,10 @@ config::detail::inner_node::lookup_rw(const tree_key& key,
     if (child_iter == _children.end()) {
         if (_dynamic) {
             base_node* const child = (key_pos == key.size() - 1) ?
-                static_cast< base_node* >(new_node()) :
-                static_cast< base_node* >(new dynamic_inner_node());
+                dynamic_cast< base_node* >(new_node()) :
+                dynamic_cast< base_node* >(new dynamic_inner_node());
+	    // The types for `new_node`
+            INV_MSG(child != nullptr, "check the return type for the function called");
             _children.insert(children_map::value_type(key[key_pos], child));
             child_iter = _children.find(key[key_pos]);
         } else {
@@ -523,6 +525,18 @@ config::positive_int_node::validate(const value_type& new_value) const
 {
     if (new_value <= 0)
         throw value_error("Must be a positive integer");
+}
+
+
+/// Copies the node.
+///
+/// \return A dynamically-allocated node.
+config::detail::base_node*
+config::positive_int_node::deep_copy(void) const
+{
+    std::unique_ptr< positive_int_node > new_node(new positive_int_node());
+    new_node->_value = _value;
+    return new_node.release();
 }
 
 

--- a/utils/config/nodes.hpp
+++ b/utils/config/nodes.hpp
@@ -181,6 +181,8 @@ public:
 /// A leaf node that holds a positive non-zero integer value.
 class positive_int_node : public int_node {
     virtual void validate(const value_type&) const;
+public:
+    virtual base_node* deep_copy(void) const;
 };
 
 

--- a/utils/config/nodes_test.cpp
+++ b/utils/config/nodes_test.cpp
@@ -85,7 +85,8 @@ ATF_TEST_CASE_BODY(bool_node__deep_copy)
     config::bool_node node;
     node.set(true);
     config::detail::base_node* raw_copy = node.deep_copy();
-    config::bool_node* copy = static_cast< config::bool_node* >(raw_copy);
+    config::bool_node* copy = dynamic_cast< config::bool_node* >(raw_copy);
+    ATF_REQUIRE(copy != nullptr);
     ATF_REQUIRE(copy->value());
     copy->set(false);
     ATF_REQUIRE(node.value());
@@ -192,7 +193,8 @@ ATF_TEST_CASE_BODY(int_node__deep_copy)
     config::int_node node;
     node.set(5);
     config::detail::base_node* raw_copy = node.deep_copy();
-    config::int_node* copy = static_cast< config::int_node* >(raw_copy);
+    config::int_node* copy = dynamic_cast< config::int_node* >(raw_copy);
+    ATF_REQUIRE(copy != nullptr);
     ATF_REQUIRE_EQ(5, copy->value());
     copy->set(10);
     ATF_REQUIRE_EQ(5, node.value());
@@ -302,8 +304,9 @@ ATF_TEST_CASE_BODY(positive_int_node__deep_copy)
     config::positive_int_node node;
     node.set(5);
     config::detail::base_node* raw_copy = node.deep_copy();
-    config::positive_int_node* copy = static_cast< config::positive_int_node* >(
+    config::positive_int_node* copy = dynamic_cast< config::positive_int_node* >(
         raw_copy);
+    ATF_REQUIRE(copy != nullptr);
     ATF_REQUIRE_EQ(5, copy->value());
     copy->set(10);
     ATF_REQUIRE_EQ(5, node.value());
@@ -419,7 +422,8 @@ ATF_TEST_CASE_BODY(string_node__deep_copy)
     config::string_node node;
     node.set("first");
     config::detail::base_node* raw_copy = node.deep_copy();
-    config::string_node* copy = static_cast< config::string_node* >(raw_copy);
+    config::string_node* copy = dynamic_cast< config::string_node* >(raw_copy);
+    ATF_REQUIRE(copy != nullptr);
     ATF_REQUIRE_EQ("first", copy->value());
     copy->set("second");
     ATF_REQUIRE_EQ("first", node.value());
@@ -523,7 +527,8 @@ ATF_TEST_CASE_BODY(strings_set_node__deep_copy)
     node.set(value);
     config::detail::base_node* raw_copy = node.deep_copy();
     config::strings_set_node* copy =
-        static_cast< config::strings_set_node* >(raw_copy);
+        dynamic_cast< config::strings_set_node* >(raw_copy);
+    ATF_REQUIRE(copy != nullptr);
     value.insert("bar");
     ATF_REQUIRE_EQ(1, copy->value().size());
     copy->set(value);


### PR DESCRIPTION
Prior to this change `positive_int_node::deep_copy` was using `int_node::deep_copy` when converting to the top-level base type, resulting in incorrect, undefined behavior when converting back to the derived type in `positive_int_node__deep_copy`. While this most likely didn't have a net negative effect for humans as `positive_int_node` is a thin wrapper over `int_node` by providing its own `validate` method, the code was technically incorrect per C++ and could have caused future problems if the `positive_int_node` no longer derived itself from `int_node` and the implementations of `int_node` and `positive_int_node` deviated from one another.

This change implements a `deep_copy` method which unwraps the node as a `positive_int_node` instead of an `int_node`, thus fixing the underlying undefined behavior.

NOTE: all of the node tests were modified to use dynamic_cast from static_cast to expose the problem seen in this issue--whether or not UBSAN was enabled. This portion of the change has a negligible runtime cost associated with it.

This fixes a valid issue found by UBSAN.

Closes: #299