### PR TITLE
Automate uploading release assets

### DIFF
--- a/admin/make-release.sh
+++ b/admin/make-release.sh
@@ -5,7 +5,14 @@
 # Example:
 # 	./admin/make-release.sh kyua-0.13
 
+readonly REPO=freebsd/kyua
+
 set -eux
+
+if ! gh auth status >/dev/null; then
+	echo "${0##*/}: ERROR: please install 'gh' and run 'gh auth login'."
+	exit 1
+fi
 
 tag=$1
 
@@ -16,6 +23,8 @@ release_root=$(realpath releases)
 
 release_dir="${release_root}/${tag}"
 release_artifact="${release_root}/${tag}.tar.gz"
+release_artifact_checksum_file="${release_artifact}.sha256"
+release_assets="${release_artifact} ${release_artifact_checksum_file}"
 
 rm -Rf "${release_dir}"
 mkdir -p "${release_dir}"
@@ -24,8 +33,11 @@ cd "${release_dir}"
 autoreconf -isv
 ./configure --enable-atf
 make dist
-mv *.tar.gz "${release_root}/${tag}.tar.gz"
+mv -- *.tar.gz "${release_root}/${tag}.tar.gz"
 cd "${release_root}"
-sha256 "${release_artifact##*/}" > "${release_artifact}.sha256"
+sha256 "${release_artifact##*/}" > "${release_artifact_checksum_file}"
+
+# shellcheck disable=SC2086
+gh release upload --repo "${REPO}" "${tag}" ${release_assets}
 
 # vim: syntax=sh


### PR DESCRIPTION
Use `gh release upload` to upload assets once they're generated.

This avoids having to do the same operation manually.

This change is similar to what is being done with the [atf][atf-pr] and [lutok][lutok-pr] projects.

[atf-pr]: https://github.com/freebsd/atf/pull/189
[lutok-pr]: https://github.com/freebsd/lutok/pull/40